### PR TITLE
Add the readyz, livez api paths with the prefix

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -43,11 +43,11 @@ objects:
             image: ${IMAGE}:${IMAGE_TAG}
             livenessProbe:
               httpGet:
-                path: /livez
+                path: /api/authz/livez
                 port: 8000
             readinessProbe:
               httpGet:
-                path: /readyz
+                path: /api/authz/readyz
                 port: 8000
             env:
               - name: SPICEDB_PRESHARED


### PR DESCRIPTION
This is a hardcoded fix, and we need a better way to ingest the config and pass it down to the deployment template. for now it will unblock the people

### PR Template:

## Describe your changes

- ...

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

