### PR TITLE
fix: rename relation methods to match generated proto implementation

### DIFF
--- a/internal/biz/relationships.go
+++ b/internal/biz/relationships.go
@@ -52,7 +52,7 @@ func NewCreateRelationshipsUsecase(repo ZanzibarRepository, logger log.Logger) *
 }
 
 func (rc *CreateRelationshipsUsecase) CreateRelationships(ctx context.Context, r []*v0.Relationship, touch bool) error {
-	rc.log.WithContext(ctx).Infof("CreateRelationships: %v %s", r, touch)
+	rc.log.WithContext(ctx).Infof("CreateTuples: %v %s", r, touch)
 	return rc.repo.CreateRelationships(ctx, r, TouchSemantics(touch))
 }
 
@@ -66,7 +66,7 @@ func NewReadRelationshipsUsecase(repo ZanzibarRepository, logger log.Logger) *Re
 }
 
 func (rc *ReadRelationshipsUsecase) ReadRelationships(ctx context.Context, req *v0.ReadTuplesRequest) (chan *RelationshipResult, chan error, error) {
-	rc.log.WithContext(ctx).Infof("ReadRelationships: %v", req)
+	rc.log.WithContext(ctx).Infof("ReadTuples: %v", req)
 
 	limit := uint32(MaxStreamingCount)
 	continuation := ContinuationToken("")
@@ -100,6 +100,6 @@ func NewDeleteRelationshipsUsecase(repo ZanzibarRepository, logger log.Logger) *
 }
 
 func (rc *DeleteRelationshipsUsecase) DeleteRelationships(ctx context.Context, r *v0.RelationTupleFilter) error {
-	rc.log.WithContext(ctx).Infof("DeleteRelationships: %v", r)
+	rc.log.WithContext(ctx).Infof("DeleteTuples: %v", r)
 	return rc.repo.DeleteRelationships(ctx, r)
 }

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -32,7 +32,7 @@ func NewHTTPServer(c *conf.Server, relationships *service.RelationshipsService, 
 	}
 
 	srv := http.NewServer(opts...)
-
+	v0.RegisterKesselTupleServiceHTTPServer(srv, relationships)
 	v0.RegisterKesselCheckServiceHTTPServer(srv, check)
 	h.RegisterKesselHealthHTTPServer(srv, health)
 	return srv

--- a/internal/service/relationships.go
+++ b/internal/service/relationships.go
@@ -26,7 +26,7 @@ func NewRelationshipsService(logger log.Logger, createUseCase *biz.CreateRelatio
 	}
 }
 
-func (s *RelationshipsService) CreateRelationships(ctx context.Context, req *pb.CreateTuplesRequest) (*pb.CreateTuplesResponse, error) {
+func (s *RelationshipsService) CreateTuples(ctx context.Context, req *pb.CreateTuplesRequest) (*pb.CreateTuplesResponse, error) {
 	s.log.Infof("Create relationships request: %v", req)
 
 	err := s.createUsecase.CreateRelationships(ctx, req.Tuples, req.GetUpsert()) //The generated .GetUpsert() defaults to false
@@ -37,7 +37,7 @@ func (s *RelationshipsService) CreateRelationships(ctx context.Context, req *pb.
 	return &pb.CreateTuplesResponse{}, nil
 }
 
-func (s *RelationshipsService) ReadRelationships(req *pb.ReadTuplesRequest, conn pb.KesselTupleService_ReadTuplesServer) error {
+func (s *RelationshipsService) ReadTuples(req *pb.ReadTuplesRequest, conn pb.KesselTupleService_ReadTuplesServer) error {
 	ctx := conn.Context()
 
 	relationships, errs, err := s.readUsecase.ReadRelationships(ctx, req)
@@ -64,7 +64,7 @@ func (s *RelationshipsService) ReadRelationships(req *pb.ReadTuplesRequest, conn
 	return nil
 }
 
-func (s *RelationshipsService) DeleteRelationships(ctx context.Context, req *pb.DeleteTuplesRequest) (*pb.DeleteTuplesResponse, error) {
+func (s *RelationshipsService) DeleteTuples(ctx context.Context, req *pb.DeleteTuplesRequest) (*pb.DeleteTuplesResponse, error) {
 	s.log.Infof("Delete relationships request: %v", req)
 
 	err := s.deleteUsecase.DeleteRelationships(ctx, req.Filter)

--- a/internal/service/relationships_test.go
+++ b/internal/service/relationships_test.go
@@ -53,7 +53,7 @@ func TestRelationshipsService_CreateRelationships(t *testing.T) {
 			expected,
 		},
 	}
-	_, err = relationshipsService.CreateRelationships(ctx, req)
+	_, err = relationshipsService.CreateTuples(ctx, req)
 	assert.NoError(t, err)
 
 	readReq := &v0.ReadTuplesRequest{Filter: &v0.RelationTupleFilter{
@@ -67,7 +67,7 @@ func TestRelationshipsService_CreateRelationships(t *testing.T) {
 	},
 	}
 	collectingServer := NewRelationships_ReadRelationshipsServerStub(ctx)
-	err = relationshipsService.ReadRelationships(readReq, collectingServer)
+	err = relationshipsService.ReadTuples(readReq, collectingServer)
 	if err != nil {
 		t.FailNow()
 	}
@@ -97,7 +97,7 @@ func TestRelationshipsService_CreateRelationshipsWithTouchFalse(t *testing.T) {
 			expected,
 		},
 	}
-	_, err = relationshipsService.CreateRelationships(ctx, req)
+	_, err = relationshipsService.CreateTuples(ctx, req)
 	assert.NoError(t, err)
 
 	readReq := &v0.ReadTuplesRequest{Filter: &v0.RelationTupleFilter{
@@ -111,7 +111,7 @@ func TestRelationshipsService_CreateRelationshipsWithTouchFalse(t *testing.T) {
 	},
 	}
 	collectingServer := NewRelationships_ReadRelationshipsServerStub(ctx)
-	err = relationshipsService.ReadRelationships(readReq, collectingServer)
+	err = relationshipsService.ReadTuples(readReq, collectingServer)
 	if err != nil {
 		t.FailNow()
 	}
@@ -127,7 +127,7 @@ func TestRelationshipsService_CreateRelationshipsWithTouchFalse(t *testing.T) {
 		assert.Equal(t, expected.Relation, resp.Tuple.Relation)
 	}
 
-	_, err = relationshipsService.CreateRelationships(ctx, req)
+	_, err = relationshipsService.CreateTuples(ctx, req)
 	assert.Equal(t, status.Convert(err).Code(), codes.AlreadyExists)
 
 }
@@ -144,7 +144,7 @@ func TestRelationshipsService_CreateRelationshipsWithBadSubjectType(t *testing.T
 			expected,
 		},
 	}
-	_, err = relationshipsService.CreateRelationships(ctx, req)
+	_, err = relationshipsService.CreateTuples(ctx, req)
 	assert.Error(t, err)
 	assert.Equal(t, status.Convert(err).Code(), codes.FailedPrecondition)
 	assert.Contains(t, err.Error(), "object definition `"+badSubjectType+"` not found")
@@ -162,7 +162,7 @@ func TestRelationshipsService_CreateRelationshipsWithBadObjectType(t *testing.T)
 			expected,
 		},
 	}
-	_, err = relationshipsService.CreateRelationships(ctx, req)
+	_, err = relationshipsService.CreateTuples(ctx, req)
 	assert.Error(t, err)
 	assert.Equal(t, status.Convert(err).Code(), codes.FailedPrecondition)
 	assert.Contains(t, err.Error(), "object definition `"+badObjectType+"` not found")
@@ -181,7 +181,7 @@ func TestRelationshipsService_DeleteRelationships(t *testing.T) {
 			expected,
 		},
 	}
-	_, err = relationshipsService.CreateRelationships(ctx, req)
+	_, err = relationshipsService.CreateTuples(ctx, req)
 	assert.NoError(t, err)
 
 	delreq := &v0.DeleteTuplesRequest{Filter: &v0.RelationTupleFilter{
@@ -193,7 +193,7 @@ func TestRelationshipsService_DeleteRelationships(t *testing.T) {
 			SubjectType: pointerize("user"),
 		},
 	}}
-	_, err = relationshipsService.DeleteRelationships(ctx, delreq)
+	_, err = relationshipsService.DeleteTuples(ctx, delreq)
 	assert.NoError(t, err)
 
 	readReq := &v0.ReadTuplesRequest{Filter: &v0.RelationTupleFilter{
@@ -208,7 +208,7 @@ func TestRelationshipsService_DeleteRelationships(t *testing.T) {
 	}
 
 	collectingServer := NewRelationships_ReadRelationshipsServerStub(ctx)
-	err = relationshipsService.ReadRelationships(readReq, collectingServer)
+	err = relationshipsService.ReadTuples(readReq, collectingServer)
 	if err != nil {
 		t.FailNow()
 	}
@@ -260,7 +260,7 @@ func TestRelationshipsService_ReadRelationships(t *testing.T) {
 			expected,
 		},
 	}
-	_, err = relationshipsService.CreateRelationships(ctx, reqCr)
+	_, err = relationshipsService.CreateTuples(ctx, reqCr)
 	assert.NoError(t, err)
 
 	req := &v0.ReadTuplesRequest{Filter: &v0.RelationTupleFilter{
@@ -275,7 +275,7 @@ func TestRelationshipsService_ReadRelationships(t *testing.T) {
 	}
 
 	collectingServer := NewRelationships_ReadRelationshipsServerStub(ctx)
-	err = relationshipsService.ReadRelationships(req, collectingServer)
+	err = relationshipsService.ReadTuples(req, collectingServer)
 	if err != nil {
 		t.FailNow()
 	}
@@ -317,7 +317,7 @@ func createRelationship(subjectId string, subjectType *v0.ObjectType, subjectRel
 	}
 }
 
-// Below is the boilerplate for creating test servers for streaming ReadRelationships rpc
+// Below is the boilerplate for creating test servers for streaming ReadTuples rpc
 
 func NewRelationships_ReadRelationshipsServerStub(ctx context.Context) *Relationships_ReadRelationshipsServerStub {
 	return &Relationships_ReadRelationshipsServerStub{


### PR DESCRIPTION
### PR Template:



## Describe your changes

- ...

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

