### PR TITLE
Update deployment to default to `latest` image tag

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -18,7 +18,7 @@ source ../.secrets/postgres.env
 
 # Export tags
 IMAGE=quay.io/cloudservices/kessel-relations
-IMAGE_TAG=10b13ce
+IMAGE_TAG=latest
 
 # Function to check if a command is available
 command_exists() {

--- a/deploy/kessel-relations.yaml
+++ b/deploy/kessel-relations.yaml
@@ -17,7 +17,7 @@ objects:
       name: dev-spicedb-config
     stringData:
       preshared_key: "averysecretpresharedkey"
-      datastore_uri: postgres://authz:SuperSecretPassword@postgres:5432/authz?sslmode=disable      
+      datastore_uri: postgres://authz:SuperSecretPassword@postgres:5432/authz?sslmode=disable
   - apiVersion: apps/v1
     kind: Deployment
     metadata:
@@ -44,12 +44,12 @@ objects:
               valueFrom:
                 secretKeyRef:
                   name: postgres-secret
-                  key: POSTGRESQL_USER            
+                  key: POSTGRESQL_USER
             - name: POSTGRESQL_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: postgres-secret
-                  key: POSTGRESQL_PASSWORD               
+                  key: POSTGRESQL_PASSWORD
             - name: PGDATA
               value: /temp/data
             image: registry.redhat.io/rhel9/postgresql-15:1-54
@@ -104,7 +104,7 @@ objects:
                 - name: spicedb
                   volumeMounts:
                   - name: bootstrap
-                    mountPath: /etc/bootstrap      
+                    mountPath: /etc/bootstrap
   - apiVersion: cloud.redhat.com/v1alpha1
     kind: ClowdApp
     metadata:
@@ -137,8 +137,8 @@ objects:
           webServices:
             public:
               enabled: true
-              apiPath: authz        
-parameters:        
+              apiPath: authz
+parameters:
   - description: Name of the ClowdApp
     name: CLOWDAPP_NAME
     value: relations
@@ -147,7 +147,7 @@ parameters:
     value: insights-ephemeral
   - description: App Image
     name: RELATIONS_IMAGE
-    value: quay.io/cloudservices/kessel-relations 
+    value: quay.io/cloudservices/kessel-relations
   - description: Image Tag
     name: RELATIONS_IMAGE_TAG
-    value: 10b13ce    
+    value: latest


### PR DESCRIPTION
Removes the image tag pin in https://github.com/project-kessel/relations-api/pull/88/files

### PR Template:

## Describe your changes

- Unpin the image tag now that the API and clients are being updated with the latest changes.

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

