### PR TITLE
Adding http handler for lookup subjects stream response

### DIFF
--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -5,6 +5,12 @@ import (
 	v0 "ciam-rebac/api/relations/v0"
 	"ciam-rebac/internal/conf"
 	"ciam-rebac/internal/service"
+	"context"
+	"encoding/json"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"io"
+	nethttp "net/http"
 
 	"github.com/go-kratos/kratos/v2/log"
 	"github.com/go-kratos/kratos/v2/middleware/recovery"
@@ -35,5 +41,51 @@ func NewHTTPServer(c *conf.Server, relationships *service.RelationshipsService, 
 	v0.RegisterKesselTupleServiceHTTPServer(srv, relationships)
 	v0.RegisterKesselCheckServiceHTTPServer(srv, check)
 	h.RegisterKesselHealthHTTPServer(srv, health)
+
+	srv.HandleFunc("/v0/subjects", func(writer nethttp.ResponseWriter, request *nethttp.Request) {
+		conn, err := grpc.NewClient(c.Grpc.Addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		if err != nil {
+			log.Fatalf("could not connect to grpc server: %v", err)
+		}
+		defer conn.Close()
+
+		lookupServiceClient := v0.NewKesselLookupServiceClient(conn)
+
+		body, err := io.ReadAll(request.Body)
+		if err != nil {
+			nethttp.Error(writer, "Failed to read lookup subject body: "+err.Error(), nethttp.StatusInternalServerError)
+			return
+		}
+
+		lookupSubjectsRequest := v0.LookupSubjectsRequest{}
+		if err := json.Unmarshal(body, &lookupSubjectsRequest); err != nil {
+			nethttp.Error(writer, "Failed to unmarshal lookup request body: "+err.Error(), nethttp.StatusBadRequest)
+			return
+		}
+		stream, err := lookupServiceClient.LookupSubjects(context.Background(), &lookupSubjectsRequest)
+		if err != nil {
+			nethttp.Error(writer, "error grpc stream", nethttp.StatusInternalServerError)
+			return
+		}
+		var responses []*v0.LookupSubjectsResponse
+		for {
+			response, err := stream.Recv()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				nethttp.Error(writer, "Failed to receive data from lookup subject stream: "+err.Error(), nethttp.StatusInternalServerError)
+				return
+			}
+			writer.Header().Set("Content-Type", "application/json")
+			writer.Header().Set("Transfer-Encoding", "chunked")
+
+			responses = append(responses, response)
+		}
+		if err := json.NewEncoder(writer).Encode(responses); err != nil {
+			nethttp.Error(writer, "Failed to encode lookup subject response: "+err.Error(), nethttp.StatusInternalServerError)
+			return
+		}
+	})
 	return srv
 }


### PR DESCRIPTION
### PR Template:

Add HTTP handler for Lookup subjects

## Describe your changes

As Kratos doesn't support stream for HTTP 

I implement an HTTP handler for the Subject Lookup endpoint. I follow the same approach as the grpc-gateway project to convert gRPC to HTTP. 

**Request**

```
curl --location --request GET 'http://localhost:8000/api/authz/v0/subjects' \
--header 'Content-Type: application/json' \
--data '{
    "subject_type": {
        "name": "group"
    },
    "subject_relation": "member",
    "relation": "member",
    "resource": {
        "type": {
            "name": "group"
        },
        "id": "omni"
    }
}' 

```

**Response**

```
[
    {
        "subject": {
            "subject": {
                "type": {
                    "name": "group"
                },
                "id": "omni"
            }
        },
        "pagination": {}
    }
]

```



## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

