### PR TITLE
Validate LookupSubjectsRequest request body

### DIFF
--- a/internal/biz/lookup.go
+++ b/internal/biz/lookup.go
@@ -50,6 +50,11 @@ func (s *GetSubjectsUsecase) Get(ctx context.Context, req *v0.LookupSubjectsRequ
 		return nil, nil, errors.BadRequest("Invalid request", "Subject type is required")
 	}
 
+	if req.Relation == "" {
+		s.log.WithContext(ctx).Infof("Missing relation in request %v", req)
+		return nil, nil, errors.BadRequest("Invalid request", "Relation is required")
+	}
+
 	if req.Resource.Type == nil {
 		s.log.WithContext(ctx).Infof("Missing Resource Type in request %v", req)
 		return nil, nil, errors.BadRequest("Invalid request", "Resource Type is required")

--- a/internal/biz/lookup.go
+++ b/internal/biz/lookup.go
@@ -50,8 +50,18 @@ func (s *GetSubjectsUsecase) Get(ctx context.Context, req *v0.LookupSubjectsRequ
 		return nil, nil, errors.BadRequest("Invalid request", "Subject type is required")
 	}
 
+	if req.Resource.Type == nil {
+		s.log.WithContext(ctx).Infof("Missing Resource Type in request %v", req)
+		return nil, nil, errors.BadRequest("Invalid request", "Resource Type is required")
+	}
+
+	if req.Resource.Id == "" {
+		s.log.WithContext(ctx).Infof("Missing Resource Id in request %v", req)
+		return nil, nil, errors.BadRequest("Invalid request", "Resource Id is required")
+	}
+
 	subs, errs, err := s.repo.LookupSubjects(ctx, req.SubjectType, subjectRelation, req.Relation, &v0.ObjectReference{
-		Type: req.Resource.Type, //Need null check
+		Type: req.Resource.Type,
 		Id:   req.Resource.Id,
 	}, limit, continuation)
 

--- a/internal/biz/lookup.go
+++ b/internal/biz/lookup.go
@@ -37,11 +37,17 @@ func (s *GetSubjectsUsecase) Get(ctx context.Context, req *v0.LookupSubjectsRequ
 	}
 
 	if req.Resource == nil {
+		s.log.WithContext(ctx).Infof("Missing Resource in request %v", req)
 		return nil, nil, errors.BadRequest("Invalid request", "Object is required")
 	}
 
 	if req.SubjectRelation != nil {
 		subjectRelation = *req.SubjectRelation
+	}
+
+	if req.SubjectType == nil {
+		s.log.WithContext(ctx).Infof("Missing SubjectType in request %v", req)
+		return nil, nil, errors.BadRequest("Invalid request", "Subject type is required")
 	}
 
 	subs, errs, err := s.repo.LookupSubjects(ctx, req.SubjectType, subjectRelation, req.Relation, &v0.ObjectReference{


### PR DESCRIPTION
### PR Template:

## Describe your changes

Sending malformed LookupSubjects requests with a missing `subject_type` causes the api to panic and restart:
```
grpcurl -plaintext -d '{"subject_relation":"member", "relation":"member", "resource": {"type":{"name":"group"}, "id":"omni"}}' localhost:9000 kessel.relations.v0.KesselLookupService.LookupSubjects
```

Server panics and returns strange errors for the user: 
```
ERROR:
  Code: Unavailable
  Message: error reading from server: EOF
```
- Returns valid error back to user
- Logs request on server, prevents server from panicking

Returned error afterwards:
```
ERROR:
  Code: InvalidArgument
  Message: Subject type is required
  Details:
  1)    {
          "@type": "type.googleapis.com/google.rpc.ErrorInfo",
          "reason": "Invalid request"
        }
```

## Ticket reference (if applicable)
Subtask of https://issues.redhat.com/browse/RHCLOUD-33199
Fixes: https://issues.redhat.com/browse/RHCLOUD-33330

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

