### PR TITLE
Remove obsolete java api make target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,21 +45,6 @@ api:
 	       --openapi_out=fq_schema_naming=true,default_response=false:. \
 	       $(API_PROTO_FILES)
 
-.PHONY: java_api
-# generate java_api proto
-# REQUIRED: protoc-gen-grpc-java plugin from https://repo.maven.apache.org/maven2/io/grpc/protoc-gen-grpc-java/1.63.0/
-# on your path. Then:
-#   chmod u+x <PATH>/protoc-gen-grpc-java-1.63.0-osx-aarch_64.exe
-#   ln -s <PATH>/protoc-gen-grpc-java-1.63.0-<ARCH>.exe protoc-gen-grpc-java
-java_api:
-	mkdir -p ./relations-client-java/src/main/java
-	protoc --proto_path=./api \
-		   --proto_path=./third_party \
-		   --java_out=./relations-client-java/src/main/java \
-		   --plugin=protoc-gen-grpc-java \
-		   --grpc-java_out=./relations-client-java/src/main/java \
-		   $(API_PROTO_FILES)
-
 .PHONY: build
 # build
 build:


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Was used to generate java protobuf files, but this now happens in the maven compile target in https://github.com/project-kessel/relations-client-java. 

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

