### PR TITLE
Fix run make targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ See also:
 
 `make build`
 
+(Configs must be specified to run binary, e.g. `./bin/ciam-rebac -conf configs`, or run make target, below.)
+
 ### Run
 
 `make run`
@@ -49,6 +51,10 @@ go build -o ./bin/ ./...
 ```
 # Generate API files (include: pb.go, http, grpc, validate, swagger) by proto file
 make api
+
+# Generate config code
+make config
+
 # Generate all files
 make all
 ```
@@ -66,17 +72,26 @@ wire
 
 ## Spicedb using docker/podman
 
-### Run the spicedb
+### Run spicedb and postgresql db with docker/podman compose
 
 `make spicedb`
 
-### Run the insights-rebac with docker compose
+This is a good option for keeping spicedb running in the background while the rebac service is run via
+`make run`, the binary or via the IDE (run/debug) during local development.
+
+### Run the insights-rebac and spicedb with docker/podman compose
 
 `make rebac`
 
-### teardown spicedb and postgresql db
+This runs everything and is a good option for testing a built rebac container image with the running binary.
+
+### Teardown spicedb and postgresql db (brought up with docker/podman compose, as above)
 
 `make spicedb/teardown`
+
+### Teardown rebac and dependencies (brought up with docker/podman compose, as above)
+
+`make rebac/teardown`
 
 ### Deploy Rebac and Spicedb using kind/kubernetes
 

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -9,6 +9,6 @@ server:
 data:
   spiceDb:
     useTLS: false
-    endpoint: "${ENDPOINT:spicedb:50051}"
+    endpoint: "${ENDPOINT:0.0.0.0:50051}"
     token: "${PRESHARED}" # token takes precedence over tokenFile
     tokenFile: "${PRESHARED_FILE:.secrets/local-spicedb-secret}"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
     environment:
       - "SPICEDB_PRESHARED=${SPICEDB_GRPC_PRESHARED_KEY}"
       # - "SPICEDB_PRESHARED_FILE=/run/secrets/spicedb_pre_shared"
-      - "ENDPOINT=spicedb:50051"
+      - "SPICEDB_ENDPOINT=spicedb:50051"
     build:
       dockerfile: Dockerfile
     profiles: ["rebac"]

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-playground/form/v4 v4.2.0 // indirect
+	github.com/google/subcommands v1.2.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/gotestyourself/gotestyourself v2.2.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,7 @@ github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/subcommands v1.2.0 h1:vWQspBTo2nEqTUFita5/KeEWlUL8kQObDFbub/EN9oE=
 github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/spicedb-kind-setup/rebac/deployment.yaml
+++ b/spicedb-kind-setup/rebac/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: relationships
-          image: quay.io/ciam_authz/insights-rebac:latest
+          image: quay.io/cloudservices/kessel-relations:latest
           ports:
             - containerPort: 8000
             - containerPort: 9000


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Updates to fix make targets that were not working. Particularly how config was managed between `make run` and `make rebac`/`docker compose`.
- Also update kind config image.
- Also update wire dependencies following `make generate`.
- Update README.md make target sections.

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

