### PR TITLE
Add logging for spicedb connection on startup

### DIFF
--- a/internal/service/check.go
+++ b/internal/service/check.go
@@ -2,8 +2,10 @@ package service
 
 import (
 	"context"
+
 	"github.com/project-kessel/relations-api/internal/biz"
 
+	"github.com/go-kratos/kratos/v2/errors"
 	"github.com/go-kratos/kratos/v2/log"
 
 	pb "github.com/project-kessel/relations-api/api/relations/v0"
@@ -24,6 +26,22 @@ func NewCheckService(logger log.Logger, checkUseCase *biz.CheckUsecase) *CheckSe
 
 func (s *CheckService) Check(ctx context.Context, req *pb.CheckRequest) (*pb.CheckResponse, error) {
 	s.log.Infof("Check permission: %v", req)
+
+	if err := req.ValidateAll(); err != nil {
+		s.log.Infof("Request failed to pass validation: %v", req)
+		return nil, errors.BadRequest("Invalid request", err.Error())
+	}
+
+	if err := req.Subject.ValidateAll(); err != nil {
+		s.log.Infof("Subject failed to pass validation: %v", req)
+		return nil, errors.BadRequest("Invalid request", err.Error())
+	}
+
+	if err := req.Resource.ValidateAll(); err != nil {
+		s.log.Infof("Resource failed to pass validation: %v", req)
+		return nil, errors.BadRequest("Invalid request", err.Error())
+	}
+
 	resp, err := s.check.Check(ctx, req)
 	if err != nil {
 		s.log.Errorf("Failed to perform check %v", err)


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Makes requests to SpiceDB during startup, exits if no connection within 30s
- - Currently, service restarts indefinitely and tries to reconnect to SpiceDB for another 30s.
- Request validation for check requests.
- Takes advantage of `WaitForReady(true)` to [block until a connection to spicedb is achieved](https://github.com/grpc/grpc-go/blob/master/Documentation/anti-patterns.md#:~:text=default%2C%20RPCs%20will,to%20a%20server). 

## Ticket reference (if applicable)
Fixes # https://issues.redhat.com/browse/RHCLOUD-33335

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

