### PR TITLE
Add waits for ready probes in e2e tests

### DIFF
--- a/internal/data/spicedb.go
+++ b/internal/data/spicedb.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	apiV0 "github.com/project-kessel/relations-api/api/relations/v0"
-	"github.com/project-kessel/relations-api/internal/biz"
-	"github.com/project-kessel/relations-api/internal/conf"
 	"io"
 	"os"
 	"strings"
+
+	apiV0 "github.com/project-kessel/relations-api/api/relations/v0"
+	"github.com/project-kessel/relations-api/internal/biz"
+	"github.com/project-kessel/relations-api/internal/conf"
 
 	v1 "github.com/authzed/authzed-go/proto/authzed/api/v1"
 	"github.com/authzed/authzed-go/v1"
@@ -63,6 +64,11 @@ func NewSpiceDbRepository(c *conf.Data, logger log.Logger) (*SpiceDbRepository, 
 
 	if err != nil {
 		return nil, nil, fmt.Errorf("error creating spicedb client: %w", err)
+	}
+
+	_, err = client.ReadSchema(context.TODO(), &v1.ReadSchemaRequest{})
+	if err != nil {
+		return nil, nil, fmt.Errorf("error testing connection to SpiceDB: %w", err)
 	}
 
 	cleanup := func() {


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Added code in the e2e test fixture to wait for the SpiceDB and Kessel Relations containers to come online before running tests
- Note: I was only able to reproduce the failures by adding a SpiceDB test call to its constructor a la https://github.com/project-kessel/relations-api/pull/109 but the waits did address it.

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

