### PR TITLE
Add stream-compatible variant of Kratos validation middleware

### DIFF
--- a/internal/server/grpc.go
+++ b/internal/server/grpc.go
@@ -23,6 +23,7 @@ func NewGRPCServer(c *conf.Server, relations *service.RelationshipsService, heal
 			logging.Server(logger),
 		),
 		grpc.StreamInterceptor(middleware.StreamLogInterceptor(logger)),
+		grpc.StreamInterceptor(middleware.StreamValidationInterceptor()),
 	}
 	if c.Grpc.Network != "" {
 		opts = append(opts, grpc.Network(c.Grpc.Network))

--- a/internal/server/middleware/validation.go
+++ b/internal/server/middleware/validation.go
@@ -1,0 +1,40 @@
+package middleware
+
+import (
+	"github.com/go-kratos/kratos/v2/errors"
+	"google.golang.org/grpc"
+)
+
+type validator interface { //Duplicated from github.com/go-kratos/kratos/v2/middleware/validate because not exported
+	Validate() error
+}
+
+func StreamValidationInterceptor() grpc.StreamServerInterceptor {
+	return func(srv any, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		wrapper := &requestValidatingWrapper{ServerStream: ss}
+		return handler(srv, wrapper)
+	}
+}
+
+type requestValidatingWrapper struct {
+	grpc.ServerStream
+}
+
+func (w *requestValidatingWrapper) RecvMsg(m interface{}) error {
+	err := w.ServerStream.RecvMsg(m)
+	if err != nil {
+		return err
+	}
+
+	if v, ok := m.(validator); ok {
+		if err = v.Validate(); err != nil {
+			return errors.BadRequest("VALIDATOR", err.Error()).WithCause(err)
+		}
+	}
+
+	return nil
+}
+
+func (w *requestValidatingWrapper) SendMsg(m interface{}) error {
+	return w.ServerStream.SendMsg(m)
+}


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Similar to the logging PR, this adds a variant of the validation that's compatible with streaming endpoints. _However_, like the Kratos middleware, it only calls the generated Validate method on the request, which doesn't consistently call the Validate method on embedded messages. See: https://github.com/project-kessel/relations-api/blob/main/api/relations/v0/lookup.pb.validate.go#L53 (it calls Validate on the pagination field, but not the other embedded messages.)

This PR is in draft state for now until there's a solution to the above, see: https://issues.redhat.com/browse/RHCLOUD-33724

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

