### PR TITLE
Enable watch service

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -46,6 +46,7 @@ services:
 
   database:
     image: "postgres"
+    command: -c track_commit_timestamp=on
     ports:
       - "5432:5432"
     environment:


### PR DESCRIPTION
Watch service require running postgres with flag track_commit_timestamp=on.

### PR Template:

## Describe your changes

- To enable watch service when using docker compose

## Ticket reference (if applicable)
Fixes #

## Checklist

* [x] Are the agreed upon acceptance criteria fulfilled?

* [x] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

