### PR TITLE
RHCLOUD-33054 - Sync protos to java client

### DIFF
--- a/.github/workflows/sync-protos.yml
+++ b/.github/workflows/sync-protos.yml
@@ -1,0 +1,44 @@
+name: sync-protos
+
+on:
+  push:
+    paths:
+      - "api/kessel/relations/v1/**"
+      - "api/kessel/relations/v1beta1/**"
+
+
+jobs:
+  build:
+    name: Sync protos to clients
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Clone target repository
+        run: git clone https://github.com/project-kessel/relations-client-java.git
+
+      - name: Copy proto files
+        run: |
+          cp -r api/kessel/relations/v1/*.proto relations-client-java/src/main/proto/kessel/relations/v1/
+          cp -r api/kessel/relations/v1beta1/*.proto relations-client-java/src/main/proto/kessel/relations/v1beta1/
+
+      - name: Commit proto files
+        run: |
+          git config --global user.name "jonathan marcantonio"
+          git config --global user.email "jmarcant@redhat.com"
+          cd relations-client-java
+          git checkout -b sync-proto-files
+          git commit -am "Sync updated proto files"
+          git remote set-url origin https://x-access-token:${{ secrets.PAT }}@github.com/project-kessel/relations-client-java.git
+          git push origin sync-proto-files
+
+      - name: Create Pull Request
+        run: |
+          cd relations-client-java
+          gh pr create --title "Sync updated proto files" \
+                       --body "This PR syncs the updated proto files" \
+                       --head sync-proto-files \
+                       --base main \
+                       --repo project-kessel/relations-client-java
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT }}
+


### PR DESCRIPTION
### PR Template:

## Describe your changes
Wanted to take some time to address a feature that we've wanted to implement in some way for a while. This PR adds an action that upon changes being made to proto files they are automatically synced over to `relations-java-client` with an open PR for review.

- Action runs upon changes to the `api/` directory
- Copies proto files from `relations-api` into `relations-java-client` and opens a PR

I have tested this out in my own forks with the action running here: https://github.com/lennysgarage/relations-api/actions/runs/10580215481/job/29314509563 with it opening a PR in my `relations-java-client` fork here: https://github.com/lennysgarage/relations-client-java/pull/4

Still required:
- a PAT, a personal access token with `repo` scope is required for creating the PR in another repo. 


## Ticket reference (if applicable)
Fixes # [RHCLOUD-33054](https://issues.redhat.com/browse/RHCLOUD-33054) 

- May also cover https://issues.redhat.com/browse/RHCLOUD-32486 
- - If we copy proto files over from the source of truth (this repo) we don't need to fetch them from the buf schema registry.

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

