### PR TITLE
Add and se bootstrap overwrite flag to true

### DIFF
--- a/deploy/kessel-relations-deploy.yaml
+++ b/deploy/kessel-relations-deploy.yaml
@@ -26,6 +26,9 @@ objects:
                     name: spicedb-schema
                 containers:
                 - name: spicedb
+                  env:
+                   - name: "SPICEDB_DATASTORE_BOOTSTRAP_OVERWRITE"
+                     value: "true"
                   volumeMounts:
                   - name: bootstrap
                     mountPath: /etc/bootstrap


### PR DESCRIPTION
- With Persistent data stores, a deploy again will error out spiceDB, we need to set the overwrite flag to "true"

### PR Template:

## Describe your changes

- ...

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

