### PR TITLE
update the dpeloyment template to make the replica count configurable…

### DIFF
--- a/deploy/kessel-relations-deploy.yaml
+++ b/deploy/kessel-relations-deploy.yaml
@@ -10,7 +10,7 @@ objects:
     spec:
       config:
         logLevel: debug
-        replicas: 1
+        replicas: ${{SPICEDB_REPLICAS}}
         datastoreEngine: postgres
         datastoreBootstrapFiles: /etc/bootstrap/schema.yaml
       secretName: spicedb-config
@@ -41,7 +41,7 @@ objects:
       envName: ${ENV_NAME}
       testing:
         iqePlugin: relations_api
-      replicas: 1
+      replicas: ${{RELATIONS_REPLICAS}}
       deployments:
         - name: relations
           podSpec:
@@ -82,3 +82,9 @@ parameters:
   - description: Image Tag
     name: RELATIONS_IMAGE_TAG
     value: latest
+  - description: Number of pods for spiceDB service
+    name: SPICEDB_REPLICAS
+    value: '1'
+  - description: Number of pods for relations service
+    name: RELATIONS_REPLICAS
+    value: '1'


### PR DESCRIPTION
… for spiceDB and Relations service

- Set the env value/paramters for replica count
- This can be overriden per env

### PR Template:

## Describe your changes

- ...

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

