### PR TITLE
Rename the ClowdApp to kessel-relations-api

### DIFF
--- a/deploy/kessel-relations-deploy.yaml
+++ b/deploy/kessel-relations-deploy.yaml
@@ -32,13 +32,12 @@ objects:
     kind: ClowdApp
     metadata:
       name: ${CLOWDAPP_NAME}
-      namesapce: ${NAMESPACE}
     spec:
       envName: ${ENV_NAME}
       testing:
         iqePlugin: relations_api
       deployments:
-        - name: relations
+        - name: api
           minReplicas: ${{RELATIONS_REPLICAS}}
           podSpec:
             image: ${RELATIONS_IMAGE}:${RELATIONS_IMAGE_TAG}
@@ -74,13 +73,10 @@ objects:
 parameters:
   - description: Name of the ClowdApp
     name: CLOWDAPP_NAME
-    value: relations
-  - description: ClowdEnvironment name
+    value: kessel-relations
+  - description: ClowdEnvironment name (ephemeral, stage, prod)
     name: ENV_NAME
-    value: ${ENV_NAME}
-  - description: Namespace to deploy into
-    name: NAMESPACE
-    value: ${NAMESPACE}
+    required: true
   - description: App Image
     name: RELATIONS_IMAGE
     value: quay.io/cloudservices/kessel-relations

--- a/deploy/kessel-relations.yaml
+++ b/deploy/kessel-relations.yaml
@@ -107,13 +107,13 @@ objects:
   - apiVersion: cloud.redhat.com/v1alpha1
     kind: ClowdApp
     metadata:
-      name: relations
+      name: kessel-relations
     spec:
       envName: ${ENV_NAME}
       testing:
         iqePlugin: relations_api
       deployments:
-        - name: relations
+        - name: api
           minReplicas: ${{RELATIONS_REPLICAS}}
           podSpec:
             image: ${RELATIONS_IMAGE}:${RELATIONS_IMAGE_TAG}
@@ -147,12 +147,9 @@ objects:
               enabled: true
               apiPath: authz
 parameters:
-  - description: Name of the ClowdApp
-    name: CLOWDAPP_NAME
-    value: relations
-  - description : ClowdEnvironment name
+  - description: ClowdEnvironment name (ephemeral, stage, prod)
     name: ENV_NAME
-    value: insights-ephemeral
+    required: true
   - description: App Image
     name: RELATIONS_IMAGE
     value: quay.io/cloudservices/kessel-relations


### PR DESCRIPTION
### PR Template:

## Describe your changes

Related to https://github.com/project-kessel/inventory-api/pull/110

- This PR renames pods in OpenShift from `relations-relations` to `kessel-relations-api` and `relations-spicedb-spicedb` to `kessel-relations-spicedb-spicedb`. I'm not sure where the extra `-spicedb` comes from, so it'll remain in the name for now.

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

