### PR TITLE
adds limits and requests to spicedb pods

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -26,6 +26,13 @@ objects:
                     name: spicedb-schema
                 containers:
                 - name: spicedb
+                  resources:
+                    requests:
+                      memory: "128Mi"
+                      cpu: "25m"
+                    limits:
+                      memory: "256Mi"
+                      cpu: "100m"                
                   volumeMounts:
                   - name: bootstrap
                     mountPath: /etc/bootstrap      

--- a/deploy/kessel-relations-deploy.yaml
+++ b/deploy/kessel-relations-deploy.yaml
@@ -26,12 +26,20 @@ objects:
                     name: spicedb-schema
                 containers:
                 - name: spicedb
+                  resources:
+                    requests:
+                      memory: "128Mi"
+                      cpu: "25m"
+                    limits:
+                      memory: "256Mi"
+                      cpu: "100m"  
                   env:
                    - name: "SPICEDB_DATASTORE_BOOTSTRAP_OVERWRITE"
                      value: "true"
                   volumeMounts:
                   - name: bootstrap
                     mountPath: /etc/bootstrap
+
   - apiVersion: cloud.redhat.com/v1alpha1
     kind: ClowdApp
     metadata:

--- a/deploy/kessel-relations.yaml
+++ b/deploy/kessel-relations.yaml
@@ -102,6 +102,13 @@ objects:
                     name: spicedb-schema
                 containers:
                 - name: spicedb
+                  resources:
+                    requests:
+                      memory: "128Mi"
+                      cpu: "25m"
+                    limits:
+                      memory: "256Mi"
+                      cpu: "100m"               
                   volumeMounts:
                   - name: bootstrap
                     mountPath: /etc/bootstrap


### PR DESCRIPTION
### PR Template:

## Describe your changes
* defines limits and requests for SpiceDB cluster pods as they are currently undefined
* updates these values in all `SpiceDBCluster` CR's in repo to ensure it matches in all env's and not have spec creep
* Values set are based on current usage with overhead added that falls within the `limitrange` defined in cluster

## How the values were determined

Based on historical data in stage, the spiceDB pods on average consumed:

|Pod                                                                             | Memory| CPU|
|-------------------------------------------------------------------|--------------|-------|
|relations-spicedb-spicedb-7875579958-mqmxm|58.49 MiB|10.73m|
|relations-spicedb-spicedb-7875579958-cp78j|45.44 MiB|9.72m|
|relations-relations-6b6b64cdd5-4rr49|41.41 MiB|9.3m|

to see how much they rose, i ran a continous loop that would hit the API and DB constantly and didnt see these values increase much more than the above. The overhead provided should be ample for now.

## Validation

Deployed to ephemeral:
```shell
$ oc get pods relationships-spicedb-spicedb-66b7cb9d94-9l4p5
NAME                                             READY   STATUS    RESTARTS   AGE
relationships-spicedb-spicedb-66b7cb9d94-9l4p5   1/1     Running   0          88s

$ oc get spicedbs relationships-spicedb -o yaml | grep -A 2 -E "requests|limits"
      {"apiVersion":"authzed.com/v1alpha1","kind":"SpiceDBCluster","metadata":{"annotations":{},"name":"relationships-spicedb","namespace":"ephemeral-veqopn"},"spec":{"config":{"datastoreBootstrapFiles":"/etc/bootstrap/schema.yaml","datastoreEngine":"postgres","logLevel":"debug","replicas":1},"patches":[{"kind":"Deployment","patch":{"spec":{"template":{"spec":{"containers":[{"name":"spicedb","resources":{"limits":{"cpu":"100m","memory":"256Mi"},"requests":{"cpu":"25m","memory":"128Mi"}},"volumeMounts":[{"mountPath":"/etc/bootstrap","name":"bootstrap"}]}],"volumes":[{"configMap":{"name":"spicedb-schema"},"name":"bootstrap"}]}}}}}],"secretName":"dev-spicedb-config"}}
  creationTimestamp: "2024-09-11T16:47:35Z"
  generation: 1
--
                limits:
                  cpu: 100m
                  memory: 256Mi
                requests:
                  cpu: 25m
                  memory: 128Mi

$ oc get pod relationships-spicedb-spicedb-66b7cb9d94-9l4p5 -o yaml | grep -A 2 -E "requests|limits"
      limits:
        cpu: 100m
        memory: 256Mi
      requests:
        cpu: 25m
        memory: 128Mi
```

## Ticket reference (if applicable)
Fixes # RHCLOUD-35034
Fixes # RHCLOUD-35035

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

