### PR TITLE
Prevent addRelationPrefix from nil pointer panic

### DIFF
--- a/internal/data/spicedb.go
+++ b/internal/data/spicedb.go
@@ -258,6 +258,8 @@ func (s *SpiceDbRepository) CreateRelationships(ctx context.Context, rels []*api
 
 	for _, rel := range rels {
 		rel.Relation = addRelationPrefix(rel.Relation, relationPrefix)
+		// subject relations are intentionally not prefixed here
+		// bc we want to reference the corresponding permission
 
 		relationshipUpdates = append(relationshipUpdates, &v1.RelationshipUpdate{
 			Operation:    operation,
@@ -288,6 +290,8 @@ func (s *SpiceDbRepository) ReadRelationships(ctx context.Context, filter *apiV1
 	}
 
 	if filter.GetRelation() != "" {
+		// subject relations are intentionally not prefixed here
+		// bc we want to reference the corresponding permission
 		tempRelation := addRelationPrefix(filter.GetRelation(), relationPrefix)
 		filter.Relation = &tempRelation
 	}

--- a/internal/data/spicedb.go
+++ b/internal/data/spicedb.go
@@ -259,6 +259,11 @@ func (s *SpiceDbRepository) CreateRelationships(ctx context.Context, rels []*api
 	for _, rel := range rels {
 		rel.Relation = addRelationPrefix(rel.Relation, relationPrefix)
 
+		if rel.Subject.GetRelation() != "" {
+			tempRelation := addRelationPrefix(rel.Subject.GetRelation(), relationPrefix)
+			rel.Subject.Relation = &tempRelation
+		}
+
 		relationshipUpdates = append(relationshipUpdates, &v1.RelationshipUpdate{
 			Operation:    operation,
 			Relationship: createSpiceDbRelationship(rel),
@@ -290,6 +295,11 @@ func (s *SpiceDbRepository) ReadRelationships(ctx context.Context, filter *apiV1
 	if filter.GetRelation() != "" {
 		tempRelation := addRelationPrefix(filter.GetRelation(), relationPrefix)
 		filter.Relation = &tempRelation
+	}
+
+	if filter.SubjectFilter.GetRelation() != "" {
+		tempRelation := addRelationPrefix(filter.SubjectFilter.GetRelation(), relationPrefix)
+		filter.SubjectFilter.Relation = &tempRelation
 	}
 
 	relationshipFilter, err := createSpiceDbRelationshipFilter(filter)
@@ -339,7 +349,7 @@ func (s *SpiceDbRepository) ReadRelationships(ctx context.Context, filter *apiV1
 					},
 					Relation: strings.TrimPrefix(msg.Relationship.Relation, relationPrefix),
 					Subject: &apiV1beta1.SubjectReference{
-						Relation: optionalStringToStringPointer(spiceDbRel.Subject.OptionalRelation),
+						Relation: optionalStringToStringPointer(strings.TrimPrefix(spiceDbRel.Subject.OptionalRelation, relationPrefix)),
 						Subject: &apiV1beta1.ObjectReference{
 							Type: spicedbTypeToKesselType(spiceDbRel.Subject.Object.ObjectType),
 							Id:   spiceDbRel.Subject.Object.ObjectId,
@@ -362,6 +372,11 @@ func (s *SpiceDbRepository) DeleteRelationships(ctx context.Context, filter *api
 	if filter.GetRelation() != "" {
 		tempRelation := addRelationPrefix(filter.GetRelation(), relationPrefix)
 		filter.Relation = &tempRelation
+	}
+
+	if filter.SubjectFilter.GetRelation() != "" {
+		tempRelation := addRelationPrefix(filter.SubjectFilter.GetRelation(), relationPrefix)
+		filter.SubjectFilter.Relation = &tempRelation
 	}
 
 	relationshipFilter, err := createSpiceDbRelationshipFilter(filter)

--- a/internal/data/spicedb.go
+++ b/internal/data/spicedb.go
@@ -259,11 +259,6 @@ func (s *SpiceDbRepository) CreateRelationships(ctx context.Context, rels []*api
 	for _, rel := range rels {
 		rel.Relation = addRelationPrefix(rel.Relation, relationPrefix)
 
-		if rel.Subject.GetRelation() != "" {
-			tempRelation := addRelationPrefix(rel.Subject.GetRelation(), relationPrefix)
-			rel.Subject.Relation = &tempRelation
-		}
-
 		relationshipUpdates = append(relationshipUpdates, &v1.RelationshipUpdate{
 			Operation:    operation,
 			Relationship: createSpiceDbRelationship(rel),
@@ -295,11 +290,6 @@ func (s *SpiceDbRepository) ReadRelationships(ctx context.Context, filter *apiV1
 	if filter.GetRelation() != "" {
 		tempRelation := addRelationPrefix(filter.GetRelation(), relationPrefix)
 		filter.Relation = &tempRelation
-	}
-
-	if filter.SubjectFilter.GetRelation() != "" {
-		tempRelation := addRelationPrefix(filter.SubjectFilter.GetRelation(), relationPrefix)
-		filter.SubjectFilter.Relation = &tempRelation
 	}
 
 	relationshipFilter, err := createSpiceDbRelationshipFilter(filter)
@@ -349,7 +339,7 @@ func (s *SpiceDbRepository) ReadRelationships(ctx context.Context, filter *apiV1
 					},
 					Relation: strings.TrimPrefix(msg.Relationship.Relation, relationPrefix),
 					Subject: &apiV1beta1.SubjectReference{
-						Relation: optionalStringToStringPointer(strings.TrimPrefix(spiceDbRel.Subject.OptionalRelation, relationPrefix)),
+						Relation: optionalStringToStringPointer(spiceDbRel.Subject.OptionalRelation),
 						Subject: &apiV1beta1.ObjectReference{
 							Type: spicedbTypeToKesselType(spiceDbRel.Subject.Object.ObjectType),
 							Id:   spiceDbRel.Subject.Object.ObjectId,
@@ -372,11 +362,6 @@ func (s *SpiceDbRepository) DeleteRelationships(ctx context.Context, filter *api
 	if filter.GetRelation() != "" {
 		tempRelation := addRelationPrefix(filter.GetRelation(), relationPrefix)
 		filter.Relation = &tempRelation
-	}
-
-	if filter.SubjectFilter.GetRelation() != "" {
-		tempRelation := addRelationPrefix(filter.SubjectFilter.GetRelation(), relationPrefix)
-		filter.SubjectFilter.Relation = &tempRelation
 	}
 
 	relationshipFilter, err := createSpiceDbRelationshipFilter(filter)

--- a/internal/data/spicedb.go
+++ b/internal/data/spicedb.go
@@ -287,8 +287,10 @@ func (s *SpiceDbRepository) ReadRelationships(ctx context.Context, filter *apiV1
 		}
 	}
 
-	tempRelation := addRelationPrefix(*filter.Relation, relationPrefix)
-	filter.Relation = &tempRelation
+	if filter.GetRelation() != "" {
+		tempRelation := addRelationPrefix(filter.GetRelation(), relationPrefix)
+		filter.Relation = &tempRelation
+	}
 
 	relationshipFilter, err := createSpiceDbRelationshipFilter(filter)
 
@@ -357,8 +359,10 @@ func (s *SpiceDbRepository) DeleteRelationships(ctx context.Context, filter *api
 		return err
 	}
 
-	tempRelation := addRelationPrefix(*filter.Relation, relationPrefix)
-	filter.Relation = &tempRelation
+	if filter.GetRelation() != "" {
+		tempRelation := addRelationPrefix(filter.GetRelation(), relationPrefix)
+		filter.Relation = &tempRelation
+	}
 
 	relationshipFilter, err := createSpiceDbRelationshipFilter(filter)
 

--- a/internal/data/spicedb_test.go
+++ b/internal/data/spicedb_test.go
@@ -343,6 +343,17 @@ func TestSupportedNsTypeTupleFilterCombinationsInReadRelationships(t *testing.T)
 	}, 0, "")
 
 	assert.NoError(t, err)
+
+	_, _, err = spiceDbRepo.ReadRelationships(ctx, &apiV1beta1.RelationTupleFilter{
+		ResourceId:        pointerize("bob_club"),
+		ResourceNamespace: pointerize("rbac"),
+		ResourceType:      pointerize("group"),
+		SubjectFilter: &apiV1beta1.SubjectFilter{
+			SubjectId: pointerize("bob"),
+		},
+	}, 0, "")
+
+	assert.NoError(t, err)
 }
 
 func TestWriteAndReadBackRelationships(t *testing.T) {

--- a/internal/data/spicedb_test.go
+++ b/internal/data/spicedb_test.go
@@ -104,6 +104,14 @@ func TestCreateRelationshipWithSubjectRelation(t *testing.T) {
 	// alice is NOT a subject of fan_binding
 	runSpiceDBCheck(t, ctx, *spiceDbRepo, "user", "rbac", "alice", "subject", "role_binding", "rbac", "fan_binding", apiV1beta1.CheckResponse_ALLOWED_FALSE)
 
+	// zed permission check rbac/role_binding:fan_binding view_the_thing rbac/user:bob
+	// bob has view_the_thing permission
+	runSpiceDBCheck(t, ctx, *spiceDbRepo, "user", "rbac", "bob", "view_the_thing", "role_binding", "rbac", "fan_binding", apiV1beta1.CheckResponse_ALLOWED_TRUE)
+
+	// zed permission check rbac/role_binding:fan_binding subject rbac/user:alice
+	// alice does NOT have view_the_thing permission
+	runSpiceDBCheck(t, ctx, *spiceDbRepo, "user", "rbac", "alice", "view_the_thing", "role_binding", "rbac", "fan_binding", apiV1beta1.CheckResponse_ALLOWED_FALSE)
+
 	// zed permission check rbac/role_binding:fan_binding t_granted rbac/role:fan
 	// check that role binding is tied to correct role
 	runSpiceDBCheck(t, ctx, *spiceDbRepo, "role", "rbac", "fan", "granted", "role_binding", "rbac", "fan_binding", apiV1beta1.CheckResponse_ALLOWED_TRUE)


### PR DESCRIPTION
### PR Template:

## Describe your changes

- If a filter does not contain a relation, dereferencing `*filter.Relation` will cause a nil pointer panic.


Solution:
- call getRelation() first to check if we need to add a prefix at all
-  getRelation() call checks if the filter is not nil and `filter.Relation` is not nil. Returns an empty string if nil.
- Added a test case without a Relation to verify.

Added test cases to cover subjectRelations.
- Subject relations do not get prefixed to differentiate the fact that we want to reference the corresponding permission

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

