### PR TITLE
RHCLOUD-34627 - Dynamically set keycloak container architecture to speedup tests

### DIFF
--- a/internal/data/LocalSpiceDbContainer.go
+++ b/internal/data/LocalSpiceDbContainer.go
@@ -95,10 +95,8 @@ func CreateContainer(opts *ContainerOptions) (*LocalSpiceDbContainer, error) {
 			return fmt.Errorf("error connecting to spiceDB: %v", err.Error())
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
 		client := grpc_health_v1.NewHealthClient(conn)
-		_, err = client.Check(ctx, &grpc_health_v1.HealthCheckRequest{})
+		_, err = client.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{})
 		return err
 	})
 

--- a/internal/data/LocalSpiceDbContainer.go
+++ b/internal/data/LocalSpiceDbContainer.go
@@ -95,7 +95,7 @@ func CreateContainer(opts *ContainerOptions) (*LocalSpiceDbContainer, error) {
 			return fmt.Errorf("error connecting to spiceDB: %v", err.Error())
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
 		client := grpc_health_v1.NewHealthClient(conn)
 		_, err = client.Check(ctx, &grpc_health_v1.HealthCheckRequest{})

--- a/internal/data/spicedb_test.go
+++ b/internal/data/spicedb_test.go
@@ -98,27 +98,27 @@ func TestCreateRelationshipWithSubjectRelation(t *testing.T) {
 
 	// zed permission check rbac/role_binding:fan_binding subject rbac/user:bob
 	// bob is a subject of fan_binding
-	runSpiceDBCheck(t, ctx, *spiceDbRepo, "user", "rbac", "bob", "subject", "role_binding", "rbac", "fan_binding", apiV1beta1.CheckResponse_ALLOWED_TRUE)
+	runSpiceDBCheck(t, ctx, spiceDbRepo, "user", "rbac", "bob", "subject", "role_binding", "rbac", "fan_binding", apiV1beta1.CheckResponse_ALLOWED_TRUE)
 
 	// zed permission check rbac/role_binding:fan_binding subject rbac/user:alice
 	// alice is NOT a subject of fan_binding
-	runSpiceDBCheck(t, ctx, *spiceDbRepo, "user", "rbac", "alice", "subject", "role_binding", "rbac", "fan_binding", apiV1beta1.CheckResponse_ALLOWED_FALSE)
+	runSpiceDBCheck(t, ctx, spiceDbRepo, "user", "rbac", "alice", "subject", "role_binding", "rbac", "fan_binding", apiV1beta1.CheckResponse_ALLOWED_FALSE)
 
 	// zed permission check rbac/role_binding:fan_binding view_the_thing rbac/user:bob
 	// bob has view_the_thing permission
-	runSpiceDBCheck(t, ctx, *spiceDbRepo, "user", "rbac", "bob", "view_the_thing", "role_binding", "rbac", "fan_binding", apiV1beta1.CheckResponse_ALLOWED_TRUE)
+	runSpiceDBCheck(t, ctx, spiceDbRepo, "user", "rbac", "bob", "view_the_thing", "role_binding", "rbac", "fan_binding", apiV1beta1.CheckResponse_ALLOWED_TRUE)
 
 	// zed permission check rbac/role_binding:fan_binding subject rbac/user:alice
 	// alice does NOT have view_the_thing permission
-	runSpiceDBCheck(t, ctx, *spiceDbRepo, "user", "rbac", "alice", "view_the_thing", "role_binding", "rbac", "fan_binding", apiV1beta1.CheckResponse_ALLOWED_FALSE)
+	runSpiceDBCheck(t, ctx, spiceDbRepo, "user", "rbac", "alice", "view_the_thing", "role_binding", "rbac", "fan_binding", apiV1beta1.CheckResponse_ALLOWED_FALSE)
 
 	// zed permission check rbac/role_binding:fan_binding t_granted rbac/role:fan
 	// check that role binding is tied to correct role
-	runSpiceDBCheck(t, ctx, *spiceDbRepo, "role", "rbac", "fan", "granted", "role_binding", "rbac", "fan_binding", apiV1beta1.CheckResponse_ALLOWED_TRUE)
+	runSpiceDBCheck(t, ctx, spiceDbRepo, "role", "rbac", "fan", "granted", "role_binding", "rbac", "fan_binding", apiV1beta1.CheckResponse_ALLOWED_TRUE)
 
 	// zed permission check rbac/role_binding:fan_binding t_granted rbac/role:fake_fan
 	// check for non-existent role not tied to role binding
-	runSpiceDBCheck(t, ctx, *spiceDbRepo, "role", "rbac", "fake_fan", "granted", "role_binding", "rbac", "fan_binding", apiV1beta1.CheckResponse_ALLOWED_FALSE)
+	runSpiceDBCheck(t, ctx, spiceDbRepo, "role", "rbac", "fake_fan", "granted", "role_binding", "rbac", "fan_binding", apiV1beta1.CheckResponse_ALLOWED_FALSE)
 }
 
 func TestSecondCreateRelationshipFailsWithTouchFalse(t *testing.T) {
@@ -628,7 +628,7 @@ func pointerize(value string) *string { //Used to turn string literals into poin
 	return &value
 }
 
-func runSpiceDBCheck(t *testing.T, ctx context.Context, spiceDbRepo SpiceDbRepository, subjectType,
+func runSpiceDBCheck(t *testing.T, ctx context.Context, spiceDbRepo *SpiceDbRepository, subjectType,
 	subjectNamespace, subjectID, relation, resourceType, resourceNamespace, resourceID string,
 	expectedAllowed apiV1beta1.CheckResponse_Allowed) {
 	check := apiV1beta1.CheckRequest{

--- a/test/kesselContainer.go
+++ b/test/kesselContainer.go
@@ -119,7 +119,6 @@ func CreateKesselAPIContainer(logger log.Logger) (*LocalKesselContainer, error) 
 	if err := pool.Retry(func() error {
 		err = checkKeycloakHealth(fmt.Sprintf("http://localhost:%s", portMetric))
 		log.Info("Waiting for Keycloak to be ready...")
-		time.Sleep(20 * time.Second)
 		return err
 	}); err != nil {
 		log.Fatalf("Could not connect to keycloak container: %s", err)
@@ -130,7 +129,7 @@ func CreateKesselAPIContainer(logger log.Logger) (*LocalKesselContainer, error) 
 		basepath   = filepath.Dir(b)
 	)
 
-	targetArch := "amd64" // or "arm64", depending on your needs
+	targetArch := runtime.GOARCH // "amd64" or "arm64", depending on your needs
 	enable_auth := fmt.Sprintf("SPICEDB_ENABLEAUTH=%t", true)
 	sso := fmt.Sprintf("SPICEDB_JWKSURL=%s", kcurl)
 	name := strings.Trim(container.Name(), "/")
@@ -141,7 +140,7 @@ func CreateKesselAPIContainer(logger log.Logger) (*LocalKesselContainer, error) 
 	resource, err := pool.BuildAndRunWithBuildOptions(&dockertest.BuildOptions{
 		Dockerfile: "Dockerfile", // Path to your Dockerfile
 		ContextDir: "../",        // Context directory for the Dockerfile
-		Platform:   "linux/amd64",
+		Platform:   "linux/" + runtime.GOARCH,
 		BuildArgs: []docker.BuildArg{
 			{Name: "TARGETARCH", Value: targetArch},
 		},


### PR DESCRIPTION
### PR Template:

## Describe your changes

- utilize `runtime.GOARCH` to set runtime architecture instead of hardcoded value (prev. amd64)
- - Should help speed up mac runs quite a bit!
- Removed `wait()` calls in `pool.Retry()` call as `pool.Retry()` [will exponentially backoff itself](https://pkg.go.dev/github.com/ory/dockertest#Pool.Retry).

on my mac m3, times for running `make pr-check` come down from roughly `170s` to `110s`.

## Ticket reference (if applicable)
Fixes # somewhat related to [RHCLOUD-34627](https://issues.redhat.com/browse/RHCLOUD-34627)

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

