### PR TITLE
updates image tag variable to leverage app interface

### DIFF
--- a/deploy/kessel-relations-deploy.yaml
+++ b/deploy/kessel-relations-deploy.yaml
@@ -40,7 +40,7 @@ objects:
         - name: api
           minReplicas: ${{RELATIONS_REPLICAS}}
           podSpec:
-            image: ${RELATIONS_IMAGE}:${RELATIONS_IMAGE_TAG}
+            image: ${RELATIONS_IMAGE}:${IMAGE_TAG}
             livenessProbe:
               httpGet:
                 path: /api/authz/livez
@@ -81,7 +81,8 @@ parameters:
     name: RELATIONS_IMAGE
     value: quay.io/redhat-services-prod/project-kessel-tenant/kessel-relations/relations-api
   - description: Image Tag
-    name: RELATIONS_IMAGE_TAG
+    name: IMAGE_TAG
+    required: true
     value: latest
   - description: Number of pods for spiceDB service
     name: SPICEDB_REPLICAS


### PR DESCRIPTION
### PR Template:

## Describe your changes

* App interface, when using openshift templates, makes the `IMAGE_TAG` variable available in all deployments for setting the image tag. This value is generated from the short hash of the git commit which matches our image tags in Quay. This will ensure the desired commit is always running versus using `latest` which has security issues and may also not be latest with regards to code changes

See [DOCS](https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/app-sre/continuous-delivery-in-app-interface.md#automatically-generated-parameters)

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

