### PR TITLE
bug fix to prevent needing auth for health checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ bin/
 .vscode/
 .idea/
 *.swp
+.docker/
 
 # Local Bonfire Config
 deploy/local_bonfire_config.yaml

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -92,8 +92,8 @@ func NewHTTPServer(c *conf.Server, relationships *service.RelationshipsService, 
 
 func NewWhiteListMatcher(ctx context.Context, operation string) bool {
 	whiteList := make(map[string]struct{})
-	whiteList["/kessel.relations.v1.KesselHealthService/GetReadyz"] = struct{}{}
-	whiteList["/kessel.relations.v1.KesselHealthService/GetLivez"] = struct{}{}
+	whiteList["/kessel.relations.v1.KesselRelationsHealthService/GetReadyz"] = struct{}{}
+	whiteList["/kessel.relations.v1.KesselRelationsHealthService/GetLivez"] = struct{}{}
 	whiteList["/grpc.health.v1.Health/Check"] = struct{}{}
 	if _, ok := whiteList[operation]; ok {
 		return false


### PR DESCRIPTION
### PR Template:

## Describe your changes

while testing enabling auth middleware, liveness probes were failing because the livez/readyz endpoints were requiring an access token
* this change fixes the whitelist for the correct names of the health check methods so that they wont require an access token when authentication is enabled for the service
* also adds `.docker` folder path to gitignore to prevent checking in local build files

```shell
# before fix, with auth enabled
$ curl localhost:8000/api/authz/readyz 
{"code":401, "reason":"UNAUTHORIZED", "message":"JWT token is missing", "metadata":{}}

# after fix with auth enabled
$ curl localhost:8000/api/authz/readyz
{"status":"OK","code":200}
```

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

