### PR TITLE
RHCLOUD-35760: updates dockerfile and deployment to allow for easier config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,16 +18,16 @@ RUN make build
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10
 
-
+RUN mkdir /config
 COPY --from=builder /workspace/bin/kessel-relations /usr/local/bin/
-COPY --from=builder /workspace/configs/config.yaml /usr/local/bin/
+COPY --from=builder /workspace/configs/config.yaml /config
 
 EXPOSE 8000
 EXPOSE 9000
 
 USER 1001
 
-ENTRYPOINT ["/usr/local/bin/kessel-relations","-conf","/usr/local/bin/config.yaml"]
+ENTRYPOINT ["/usr/local/bin/kessel-relations","-conf","/config/config.yaml"]
 
 LABEL name="kessel-relations-api" \
       version="0.0.1" \

--- a/deploy/kessel-relations-deploy.yaml
+++ b/deploy/kessel-relations-deploy.yaml
@@ -63,9 +63,14 @@ objects:
             - name: schema
               configMap:
                 name: spicedb-schema
+            - name: relations-api-config
+              configMap:
+                name: relations-api-config
             volumeMounts:
               - name: schema
                 mountPath: /etc/schema
+              - name: relations-api-config
+                mountPath: /config
           webServices:
             public:
               enabled: true

--- a/deploy/kessel-relations.yaml
+++ b/deploy/kessel-relations.yaml
@@ -4,6 +4,31 @@ metadata:
   name: relations
 objects:
   - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: relations-api-config
+    data:
+      config.yaml: |
+        server:
+          http:
+            addr: "${HTTPADDR:0.0.0.0:8000}"
+            timeout: 1s
+            pathprefix: "/api/authz"
+          grpc:
+            addr: "${GRPCADDR:0.0.0.0:9000}"
+            timeout: 1s
+          minLogLevel: Info
+          auth:
+            enableAuth: "${ENABLEAUTH:false}"
+            jwksUrl: "${JWKSURL:http://0.0.0.0:8180/jwks}"
+        data:
+          spiceDb:
+            useTLS: false
+            endpoint: "${ENDPOINT:0.0.0.0:50051}"
+            token: "${PRESHARED}" # token takes precedence over tokenFile
+            tokenFile: "${PRESHARED_FILE:.secrets/local-spicedb-secret}"
+            schemaFile: "${SCHEMA_FILE:deploy/schema.zed}"
+  - apiVersion: v1
     kind: Secret
     metadata:
       name: postgres-secret
@@ -103,7 +128,7 @@ objects:
                       cpu: "25m"
                     limits:
                       memory: "256Mi"
-                      cpu: "100m"               
+                      cpu: "100m"
   - apiVersion: cloud.redhat.com/v1alpha1
     kind: ClowdApp
     metadata:
@@ -139,9 +164,14 @@ objects:
             - name: schema
               configMap:
                 name: spicedb-schema
+            - name: relations-api-config
+              configMap:
+                name: relations-api-config
             volumeMounts:
               - name: schema
                 mountPath: /etc/schema
+              - name: relations-api-config
+                mountPath: /config
           webServices:
             public:
               enabled: true
@@ -161,4 +191,4 @@ parameters:
     value: '1'
   - description: Number of pods for relations service
     name: RELATIONS_REPLICAS
-    value: '1'    
+    value: '1'


### PR DESCRIPTION
### PR Template:

## Describe your changes

* updates the dockerfile to:
  * create a path for config vs using `/usr/local/bin` so that a config can be managed externally and not overwrite the directory
  * updates the entrypoint command for new config path
* adds a default config to ephemeral deployment
* updates the pod spec to mount the configmap as a file

Purpose:
The config is currently hard backed into the dockerfile which makes it difficult to provide different configs for every env, especially with some using auth, some not, and having different auth endpoints.

For ephemeral, the configmap is created with the deployment, allowing for local edits/testing

For stage/prod, the configmap will be deployed via App interface and is expected to exist to run. This will allow for configuring values that are env specific.

The config is still copied over to the image for the sake of local testing, but when using kubernetes, the configmap will be required after this change.

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

