### PR TITLE
Parameterize relations service memory,cpu requests and limits

### DIFF
--- a/deploy/kessel-relations-deploy.yaml
+++ b/deploy/kessel-relations-deploy.yaml
@@ -49,6 +49,13 @@ objects:
               httpGet:
                 path: /api/authz/readyz
                 port: 8000
+            resources:
+              requests:
+                memory: ${RELATIONS_REQUESTS_MEMORY}
+                cpu: ${RELATIONS_REQUESTS_CPU}
+              limits:
+                memory: ${RELATIONS_LIMITS_MEMORY} 
+                cpu: ${RELATIONS_LIMITS_CPU}
             env:
               - name: SPICEDB_PRESHARED
                 valueFrom:
@@ -125,3 +132,15 @@ parameters:
   - description: CPU limit for SpiceDB
     name: SPICEDB_LIMITS_CPU
     value: '100m'
+  - description: Memory request for relations service
+    name: RELATIONS_REQUESTS_MEMORY
+    value: '512Mi'
+  - description: CPU request for relations service
+    name: RELATIONS_REQUESTS_CPU
+    value: '150m'
+  - description: Memory limit for relations service
+    name: RELATIONS_LIMITS_MEMORY
+    value: '1Gi'
+  - description: CPU limit for relations service
+    name: RELATIONS_LIMITS_CPU
+    value: '300m'

--- a/deploy/kessel-relations-deploy.yaml
+++ b/deploy/kessel-relations-deploy.yaml
@@ -54,7 +54,7 @@ objects:
                 memory: ${RELATIONS_REQUESTS_MEMORY}
                 cpu: ${RELATIONS_REQUESTS_CPU}
               limits:
-                memory: ${RELATIONS_LIMITS_MEMORY} 
+                memory: ${RELATIONS_LIMITS_MEMORY}
                 cpu: ${RELATIONS_LIMITS_CPU}
             env:
               - name: SPICEDB_PRESHARED


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Parameterize default resources setting for relations service.
- requests of 150m cpu and 512Mi memory
- limit of 300m cpu and 1Gi memory

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

