### PR TITLE
Parameterize spicedb settings

### DIFF
--- a/deploy/kessel-relations-deploy.yaml
+++ b/deploy/kessel-relations-deploy.yaml
@@ -160,8 +160,8 @@ parameters:
     name: SPICEDB_QUANTIZATION_STALENESS_PERCENT
     value: '0.1'
   - description: Maximum number of open connections to datastore
-    name: SPICEDB_DATASTORE_CONN_POOL_READ_MAX_OPEN
+    name: SPICEDB_DATASTORE_MAX_CONN_OPEN
     value: '20'
   - description: Minimum number of open connections to datastore
-    name: SPICEDB_DATASTORE_CONN_POOL_READ_MIN_OPEN
+    name: SPICEDB_DATASTORE_MIN_CONN_OPEN
     value: '20'

--- a/deploy/kessel-relations-deploy.yaml
+++ b/deploy/kessel-relations-deploy.yaml
@@ -28,6 +28,15 @@ objects:
                     limits:
                       memory: ${SPICEDB_LIMITS_MEMORY}
                       cpu: ${SPICEDB_LIMITS_CPU}
+                  env:
+                    - name: SPICEDB_DATASTORE_REVISION_QUANTIZATION_INTERVAL
+                      value: ${SPICEDB_QUANTIZATION_INTERVAL}
+                    - name: SPICEDB_DATASTORE_REVISION_QUANTIZATION_MAX_STALENESS_PERCENT
+                      value: ${SPICEDB_QUANTIZATION_STALENESS_PERCENT}
+                    - name: SPICEDB_DATASTORE_CONN_POOL_READ_MAX_OPEN
+                      value: ${SPICEDB_DATASTORE_MAX_CONN_OPEN}
+                    - name: SPICEDB_DATASTORE_CONN_POOL_READ_MIN_OPEN
+                      value: ${SPICEDB_DATASTORE_MIN_CONN_OPEN}
   - apiVersion: cloud.redhat.com/v1alpha1
     kind: ClowdApp
     metadata:
@@ -144,3 +153,15 @@ parameters:
   - description: CPU limit for relations service
     name: RELATIONS_LIMITS_CPU
     value: '300m'
+  - description: SpiceDB quantization interval in seconds
+    name: SPICEDB_QUANTIZATION_INTERVAL
+    value: '5s'
+  - description: SpiceDB quantization max staleness percent (float)
+    name: SPICEDB_QUANTIZATION_STALENESS_PERCENT
+    value: '0.1'
+  - description: Maximum number of open connections to datastore
+    name: SPICEDB_DATASTORE_CONN_POOL_READ_MAX_OPEN
+    value: '20'
+  - description: Minimum number of open connections to datastore
+    name: SPICEDB_DATASTORE_CONN_POOL_READ_MIN_OPEN
+    value: '20'


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Parameterizes spicedb params to defaults
- - Connections per pod max & min (20)
- - Quantization interval (5s)
- - Quantization staleness percentage (0.1)

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

