### PR TITLE
convert SPICEDB_ENABLE_WATCHABLE_SCHEMA_CACHE flag to string

### DIFF
--- a/deploy/kessel-relations-deploy.yaml
+++ b/deploy/kessel-relations-deploy.yaml
@@ -53,7 +53,7 @@ objects:
                     - name: SPICEDB_DATASTORE_CONN_POOL_READ_MIN_OPEN
                       value: ${SPICEDB_DATASTORE_MIN_CONN_OPEN}
                     - name: SPICEDB_ENABLE_EXPERIMENTAL_WATCHABLE_SCHEMA_CACHE
-                      value: ${{SPICEDB_ENABLE_WATCHABLE_SCHEMA_CACHE}}
+                      value: ${SPICEDB_ENABLE_WATCHABLE_SCHEMA_CACHE}
                   volumeMounts:
                     - name: rds-tls
                       mountPath: /etc/tls/rds.pem
@@ -192,4 +192,4 @@ parameters:
     value: '20'
   - description: Enable the experimental schema cache which makes use of the Watch API for automatic updates
     name: SPICEDB_ENABLE_WATCHABLE_SCHEMA_CACHE
-    value: false
+    value: 'false'

--- a/deploy/kessel-relations-deploy.yaml
+++ b/deploy/kessel-relations-deploy.yaml
@@ -53,7 +53,7 @@ objects:
                     - name: SPICEDB_DATASTORE_CONN_POOL_READ_MIN_OPEN
                       value: ${SPICEDB_DATASTORE_MIN_CONN_OPEN}
                     - name: SPICEDB_ENABLE_EXPERIMENTAL_WATCHABLE_SCHEMA_CACHE
-                      value: ${SPICEDB_ENABLE_WATCHABLE_SCHEMA_CACHE}
+                      value: ${{SPICEDB_ENABLE_WATCHABLE_SCHEMA_CACHE}}
                   volumeMounts:
                     - name: rds-tls
                       mountPath: /etc/tls/rds.pem


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Make everything a string, we like strings. strings are valid as true/false input
`podman run --rm authzed/spicedb:v1.31.0 serve --enable-experimental-watchable-schema-cache='false'` works
`podman run --rm authzed/spicedb:v1.31.0 serve --enable-experimental-watchable-schema-cache='nah'` does not

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

