### PR TITLE
Modify REadyZ implementation to check for backend only during startup

### DIFF
--- a/internal/service/health.go
+++ b/internal/service/health.go
@@ -10,6 +10,7 @@ import (
 type HealthService struct {
 	pb.UnimplementedKesselRelationsHealthServiceServer
 	backendUseCase *biz.IsBackendAvaliableUsecase
+	isReady        bool
 }
 
 func NewHealthService(backendUsecase *biz.IsBackendAvaliableUsecase) *HealthService {
@@ -23,9 +24,12 @@ func (s *HealthService) GetLivez(ctx context.Context, req *pb.GetLivezRequest) (
 }
 
 func (s *HealthService) GetReadyz(ctx context.Context, req *pb.GetReadyzRequest) (*pb.GetReadyzResponse, error) {
-	err := s.backendUseCase.IsBackendAvailable()
-	if err != nil {
-		return &pb.GetReadyzResponse{Status: "Unavailable", Code: 503}, nil
+	if !s.isReady {
+		err := s.backendUseCase.IsBackendAvailable()
+		if err != nil {
+			return &pb.GetReadyzResponse{Status: "Unavailable", Code: 503}, nil
+		}
+		s.isReady = true
 	}
 	return &pb.GetReadyzResponse{Status: "OK", Code: 200}, nil
 }


### PR DESCRIPTION
- Will not probe spiceDB for every readyZ probe for relations

### PR Template:

## Describe your changes

- ...

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

