### PR TITLE
RHCLOUD-36078 - LookupResources ignores subject relations

### DIFF
--- a/internal/data/spicedb.go
+++ b/internal/data/spicedb.go
@@ -197,6 +197,7 @@ func (s *SpiceDbRepository) LookupResources(ctx context.Context, resouce_type *a
 		ResourceObjectType: kesselTypeToSpiceDBType(resouce_type),
 		Permission:         relation,
 		Subject: &v1.SubjectReference{
+			OptionalRelation: optionalStringPointerToString(subject.Relation),
 			Object: &v1.ObjectReference{
 				ObjectType: kesselTypeToSpiceDBType(subject.Subject.Type),
 				ObjectId:   subject.Subject.Id,
@@ -554,6 +555,13 @@ func kesselTypeToSpiceDBType(kesselType *apiV1beta1.ObjectType) string {
 	}
 
 	return kesselType.Name
+}
+
+func optionalStringPointerToString(optional *string) string {
+	if optional == nil {
+		return ""
+	}
+	return *optional
 }
 
 func optionalStringToStringPointer(optional string) *string {


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Add missing OptionalRelation field to Subject in LookupResources call
- Add test case for Lookupresources utilizing subject relation field.

## Ticket reference (if applicable)
Fixes # https://issues.redhat.com/browse/RHCLOUD-36078

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

