### PR TITLE
RHCLOUD-35152 - Update builds to go 1.22.7 inline with go.mod

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21.x'
+          go-version-file: 'go.mod'
           cache: true
       - name: Install dependencies
         run: go get ./...

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21.x'
+          go-version-file: 'go.mod'
       - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -11,10 +11,10 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
-      - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ USER root
 RUN microdnf install -y tar gzip make which
 
 # install platform specific go version
-RUN curl -O -J  https://dl.google.com/go/go1.22.0.linux-${TARGETARCH}.tar.gz
-RUN tar -C /usr/local -xzf go1.22.0.linux-${TARGETARCH}.tar.gz
+RUN curl -O -J  https://dl.google.com/go/go1.22.7.linux-${TARGETARCH}.tar.gz
+RUN tar -C /usr/local -xzf go1.22.7.linux-${TARGETARCH}.tar.gz
 RUN ln -s /usr/local/go/bin/go /usr/local/bin/go
 
 WORKDIR /workspace

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -5,8 +5,8 @@ USER root
 RUN microdnf install -y tar gzip unzip
 
 # install platform specific go version
-RUN curl -O -J  https://dl.google.com/go/go1.22.0.linux-${TARGETARCH}.tar.gz
-RUN tar -C /usr/local -xzf go1.22.0.linux-${TARGETARCH}.tar.gz
+RUN curl -O -J  https://dl.google.com/go/go1.22.7.linux-${TARGETARCH}.tar.gz
+RUN tar -C /usr/local -xzf go1.22.7.linux-${TARGETARCH}.tar.gz
 RUN ln -s /usr/local/go/bin/go /usr/local/bin/go
 
 # Install protoc plugins


### PR DESCRIPTION
### PR Template:

Doesn't seem to directly be responsible for failing containerized tests like the ticket mentions, but thought it'd make sense to upgrade it at the same time.

## Describe your changes

- Update go workflows to utilize the same version as specified in go.mod 
- Update dockerfile builds to use same version as go.mod: 1.22.7

## Ticket reference (if applicable)
Fixes # https://issues.redhat.com/browse/RHCLOUD-35152

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

