### PR TITLE
RHCLOUD-36941 - Fix tests that have actuals in expected parameter

### DIFF
--- a/internal/data/spicedb_test.go
+++ b/internal/data/spicedb_test.go
@@ -146,7 +146,7 @@ func TestSecondCreateRelationshipFailsWithTouchFalse(t *testing.T) {
 
 	err = spiceDbRepo.CreateRelationships(ctx, rels, touch)
 	assert.Error(t, err)
-	assert.Equal(t, status.Convert(err).Code(), codes.AlreadyExists)
+	assert.Equal(t, codes.AlreadyExists, status.Convert(err).Code())
 
 	container.WaitForQuantizationInterval()
 
@@ -338,7 +338,7 @@ func TestCreateRelationshipFailsWithBadSubjectType(t *testing.T) {
 
 	err = spiceDbRepo.CreateRelationships(ctx, rels, touch)
 	assert.Error(t, err)
-	assert.Equal(t, status.Convert(err).Code(), codes.FailedPrecondition)
+	assert.Equal(t, codes.FailedPrecondition, status.Convert(err).Code())
 	assert.Contains(t, err.Error(),
 		fmt.Sprintf("object definition `%s/%s` not found", "rbac", badSubjectType))
 }
@@ -360,7 +360,7 @@ func TestCreateRelationshipFailsWithBadObjectType(t *testing.T) {
 
 	err = spiceDbRepo.CreateRelationships(ctx, rels, touch)
 	assert.Error(t, err)
-	assert.Equal(t, status.Convert(err).Code(), codes.FailedPrecondition)
+	assert.Equal(t, codes.FailedPrecondition, status.Convert(err).Code())
 	assert.Contains(t, err.Error(),
 		fmt.Sprintf("object definition `%s/%s` not found", "rbac", badObjectType))
 

--- a/internal/server/middleware/validation_test.go
+++ b/internal/server/middleware/validation_test.go
@@ -50,7 +50,7 @@ func TestValidationMiddleware_InvalidRequest(t *testing.T) {
 		Resource: &v1beta1.ObjectReference{},
 	})
 	assert.Error(t, err)
-	assert.Equal(t, resp, nil)
+	assert.Equal(t, nil, resp)
 }
 
 type DummyServerStream struct {

--- a/internal/service/health_test.go
+++ b/internal/service/health_test.go
@@ -23,7 +23,7 @@ func TestHealthService_GetLivez(t *testing.T) {
 	resp, err := service.GetLivez(ctx, &pb.GetLivezRequest{})
 
 	assert.NoError(t, err)
-	assert.Equal(t, resp, &pb.GetLivezResponse{Status: "OK", Code: 200})
+	assert.Equal(t, &pb.GetLivezResponse{Status: "OK", Code: 200}, resp)
 }
 
 func TestHealthService_GetReadyz_SpiceDBAvailable(t *testing.T) {
@@ -37,7 +37,7 @@ func TestHealthService_GetReadyz_SpiceDBAvailable(t *testing.T) {
 	resp, err := service.GetReadyz(ctx, &pb.GetReadyzRequest{})
 
 	assert.NoError(t, err)
-	assert.Equal(t, resp, &pb.GetReadyzResponse{Status: "OK", Code: 200})
+	assert.Equal(t, &pb.GetReadyzResponse{Status: "OK", Code: 200}, resp)
 }
 
 func TestHealthService_GetReadyz_SpiceDBUnavailable(t *testing.T) {
@@ -51,7 +51,7 @@ func TestHealthService_GetReadyz_SpiceDBUnavailable(t *testing.T) {
 	resp, err := service.GetReadyz(ctx, &pb.GetReadyzRequest{})
 
 	assert.NoError(t, err)
-	assert.Equal(t, resp, &pb.GetReadyzResponse{Status: "Unavailable", Code: 503})
+	assert.Equal(t, &pb.GetReadyzResponse{Status: "Unavailable", Code: 503}, resp)
 }
 
 func TestHealthService_GetReadyz_StillReadyAfterBackendLaterUnavailable(t *testing.T) {
@@ -64,19 +64,19 @@ func TestHealthService_GetReadyz_StillReadyAfterBackendLaterUnavailable(t *testi
 	resp, err := service.GetReadyz(ctx, &pb.GetReadyzRequest{})
 
 	assert.NoError(t, err)
-	assert.Equal(t, resp, &pb.GetReadyzResponse{Status: "Unavailable", Code: 503})
+	assert.Equal(t, &pb.GetReadyzResponse{Status: "Unavailable", Code: 503}, resp)
 
 	d.SetAvailable(true)
 	resp, err = service.GetReadyz(ctx, &pb.GetReadyzRequest{})
 
 	assert.NoError(t, err)
-	assert.Equal(t, resp, &pb.GetReadyzResponse{Status: "OK", Code: 200})
+	assert.Equal(t, &pb.GetReadyzResponse{Status: "OK", Code: 200}, resp)
 
 	d.SetAvailable(false)
 	resp, err = service.GetReadyz(ctx, &pb.GetReadyzRequest{})
 
 	assert.NoError(t, err)
-	assert.Equal(t, resp, &pb.GetReadyzResponse{Status: "OK", Code: 200})
+	assert.Equal(t, &pb.GetReadyzResponse{Status: "OK", Code: 200}, resp)
 }
 
 type DummyZanzibar struct {

--- a/internal/service/relationships_test.go
+++ b/internal/service/relationships_test.go
@@ -140,7 +140,7 @@ func TestRelationshipsService_CreateRelationshipsWithTouchFalse(t *testing.T) {
 	}
 
 	_, err = relationshipsService.CreateTuples(ctx, req)
-	assert.Equal(t, status.Convert(err).Code(), codes.AlreadyExists)
+	assert.Equal(t, codes.AlreadyExists, status.Convert(err).Code())
 
 }
 
@@ -172,7 +172,7 @@ func TestRelationshipsService_CreateRelationshipsWithBadSubjectType(t *testing.T
 	}
 	_, err = relationshipsService.CreateTuples(ctx, req)
 	assert.Error(t, err)
-	assert.Equal(t, status.Convert(err).Code(), codes.FailedPrecondition)
+	assert.Equal(t, codes.FailedPrecondition, status.Convert(err).Code())
 	assert.Contains(t, err.Error(),
 		fmt.Sprintf("object definition `%s/%s` not found", badSubjectType.GetNamespace(), badSubjectType.GetName()))
 }


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Swap tests expected and actual values around

## Ticket reference (if applicable)
Fixes # https://issues.redhat.com/browse/RHCLOUD-36941

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

