### PR TITLE
Make spiceDB log level configurable

### DIFF
--- a/deploy/kessel-relations-deploy.yaml
+++ b/deploy/kessel-relations-deploy.yaml
@@ -9,7 +9,7 @@ objects:
       name: ${CLOWDAPP_NAME}-spicedb
     spec:
       config:
-        logLevel: debug
+        logLevel: ${SPICEDB_LOG_LEVEL}
         replicas: ${{SPICEDB_REPLICAS}}
         datastoreEngine: postgres
       secretName: spicedb-config
@@ -193,3 +193,6 @@ parameters:
   - description: Enable the experimental schema cache which makes use of the Watch API for automatic updates
     name: SPICEDB_ENABLE_WATCHABLE_SCHEMA_CACHE
     value: 'false'
+  - description: SpiceDB log level - possible values ("trace", "debug", "info", "warn", "error")
+    name: SPICEDB_LOG_LEVEL
+    value: debug


### PR DESCRIPTION
- Set the default as "debug"
- Make the log level configurable in the deployment template

### PR Template:

## Describe your changes

- ...

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

