### PR TITLE
RHCLOUD-37204: updates to add FIPS compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@ make init
 
 ### Build
 
-`make build`
+```shell
+# when building locally, use the local-build option as FIPS_ENABLED is set by default for builds
+make local-build
+```
 
 (Configs must be specified to run binary, e.g. `./bin/kessel-relations -conf configs`, or run make target, below.)
 
@@ -129,13 +132,13 @@ You should have logged into a valid openshift cluster using the oc login command
 #### Option 1: Using the config from app-interface (RedHat Internal only)
 
 * Create a config map inside a local temp directory. You can leverage the template [here](./deploy/schema-configmaps/schema-configmap-template.yaml). The template can be used to inject any schema definition file you like by providing the contents of a schema definition file as the parameter.
-  
+
   ```shell
   # Example, create a configmap using the current default schema
   TEMP_DIR=$(mktemp -d)
 
   # SCHEMA_FILE can be a path to any desired schema definition file in yaml format
-  SCHEMA_FILE=./deploy/schema.yaml 
+  SCHEMA_FILE=./deploy/schema.yaml
 
   oc process --local \
     -f deploy/schema-configmaps/schema-configmap-template.yaml \
@@ -144,7 +147,7 @@ You should have logged into a valid openshift cluster using the oc login command
   ```
 
 * Run the following command:
-  * `bonfire deploy relations --import-configmaps  --configmaps-dir $TEMP_DIR` 
+  * `bonfire deploy relations --import-configmaps  --configmaps-dir $TEMP_DIR`
 
 #### Option 2: Using the deploy.sh script in this repository
 
@@ -181,3 +184,14 @@ Example:
 - Updates config bonfire file and add rbac component
 - Deploys rbac together with relationships application
   - Hardcoded image is used with grpc client for calling relationships
+
+## Validating FIPS
+Relations API is configured to build with FIPS capable libraries and produce FIPS capaable binaries when running on FIPS enabled clusters.
+To validate the current running container is FIPS capable:
+```shell
+# exec or rsh into running pod
+# using fips-detect (https://github.com/acardace/fips-detect)
+fips-detect /usr/local/bin/kessel-relations
+# using go tool
+go tool nm /usr/local/bin/kessel-relations | grep FIPS
+```

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -1,6 +1,9 @@
 set -exv
 
-IMAGE="quay.io/cloudservices/kessel-relations"
+if [[ -z "$IMAGE" ]]; then
+    IMAGE="quay.io/cloudservices/kessel-relations"
+fi
+
 IMAGE_TAG=$(git rev-parse --short=7 HEAD)
 GIT_COMMIT=$(git rev-parse --short HEAD)
 SECURITY_COMPLIANCE_TAG="sc-$(date +%Y%m%d)-$(git rev-parse --short=7 HEAD)"

--- a/cmd/kessel-relations/fips.go
+++ b/cmd/kessel-relations/fips.go
@@ -1,0 +1,13 @@
+//go:build fips_enabled
+// +build fips_enabled
+
+package main
+
+import (
+	_ "crypto/tls/fipsonly"
+	"fmt"
+)
+
+func init() {
+	fmt.Println("***** Starting with FIPS crypto enabled *****")
+}


### PR DESCRIPTION
### PR Template:

## Describe your changes

**Adds `fips.go`:**
* new package to restrict all TLS configuration to FIPS-approved settings (See [fipsonly.go](https://go.dev/src/crypto/tls/fipsonly/fipsonly.go))

**Updates to Dockerfile:**
* adds the `go-toolset` package to both  the builder container and the final container versus installing Go from upstream
  * the version of Go from `go-toolset` contains modifications made for RHEL which replaces BoringSSL with OpenSSL. OpenSSL is approved and validated for FedRAMP and FIPS, BoringSSL is not
  * making `go tool` available on the final image will also aid in proving FIPS compliance for audits
* installs `fips-detect` to simplify proving FIPS validation during audits as well (More on [fips-detect](https://github.com/acardace/fips-detect)

**Updates to Makefile:**
* adds a `FIPS_ENABLED` var that defaults to true
* adds some GO env vars to be more explicit for builds, including setting GOBUILDFLAGS to remove paths with compiler and assembler (cleaner errors for things like panic's by stripping full paths to packages)
* adds conditional to enforce FIPS during build if FIPS_ENABLED=true
* updates build command to use new buildflags and account for FIPS or not
* adds `local-build` target since building with FIPS_ENABLED will fail locally and wanted to make it easier to build locally without having to set FIPS_ENABLED=false
* adds `docker-build-push` target for building the docker image for testing if needed (FIPS enabled)
* updates build-deploy.sh for overriding the IMAGE repo for building/testing images

Updates to README:
* adds info on building locally 
* adds info on how to validate FIPS for audits/any other reason

Some notes/useful links:
* many of the FIPS changes to build flags, fips.go etc are well tested in SREP for ensuring all operators deployed for managed openshift are FIPS compliant as they run in FedRAMP. Some info on those changes are available [HERE](https://github.com/openshift/boilerplate/tree/master/boilerplate/openshift/golang-osd-operator#fips-federal-information-processing-standards) and can also be found in the Makefile in the same repo path
* These same changes are being made in inventory API as well (https://github.com/project-kessel/inventory-api/pull/293)
* [Is your Go Application FIPS Compliant?](https://developers.redhat.com/articles/2022/05/31/your-go-application-fips-compliant)
* long term we probably dont want to install go onto the running image, or install fips-detect at all but for the purpose of the FedRAMP build out and SCR ive added them now to simplify testing. We can remove them at a later day and come up with a better validation proof method

Validation: 
See RHCLOUD-37204 comments for lots of validation, ive tested this in a non-FedRAMP cluster (ephemeral) and in the FedRAMP int cluster

## Ticket reference (if applicable)
For RHCLOUD-37204

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

