### PR TITLE
Update network check compatibility with podman

### DIFF
--- a/spicedb/start-relations-api.sh
+++ b/spicedb/start-relations-api.sh
@@ -3,5 +3,5 @@ set -e
 # Function to check if a command is available
 source ./spicedb/check_docker_podman.sh
 NETWORK_CHECK=$(${DOCKER} network ls --filter name=kessel --format json)
-if [[ -z "${NETWORK_CHECK}" ]]; then ${DOCKER} network create kessel; fi
+if [[ -z "${NETWORK_CHECK}" || "${NETWORK_CHECK}" == "[]" ]]; then ${DOCKER} network create kessel; fi
 ${DOCKER} compose --env-file ./spicedb/.env --profile relations-api -f ./docker-compose.yaml up -d --build

--- a/spicedb/start-spicedb.sh
+++ b/spicedb/start-spicedb.sh
@@ -3,5 +3,5 @@ set -e
 # Function to check if a command is available
 source ./spicedb/check_docker_podman.sh
 NETWORK_CHECK=$(${DOCKER} network ls --filter name=kessel --format json)
-if [[ -z "${NETWORK_CHECK}" ]]; then ${DOCKER} network create kessel; fi
+if [[ -z "${NETWORK_CHECK}" || "${NETWORK_CHECK}" == "[]" ]]; then ${DOCKER} network create kessel; fi
 ${DOCKER} compose --env-file ./spicedb/.env -f ./docker-compose.yaml up -d


### PR DESCRIPTION
### PR Template:

## Describe your changes
System info: 
Mac OS 15.2
podman version 5.3.1

- When trying to run `make relations-api-up` I would encounter the error: 
```
Error response from daemon: unable to find network with name or ID kessel: network not found
Error: executing /usr/local/bin/docker-compose --env-file ./spicedb/.env --profile relations-api -f ./docker-compose.yaml up -d --build: exit status 1
make: *** [relations-api-up] Error 1
```  
Which indicates I don't have the network 'kessel'. Seems that docker and podman differ in their response to querying for a empty network. 

Podman: `network ls --filter name=kessel --format json` returns `[]`


- Related to https://github.com/project-kessel/relations-api/pull/342

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

