### PR TITLE
updates to allow for testing services with notifications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,11 @@ spicedb-up:
 	./spicedb/start-spicedb.sh
 .PHONY: spicedb-up
 
+# uses alternative postgres port to avoid conflicts
+spicedb-alt-up:
+	./spicedb/start-spicedb-alt-port.sh
+.PHONY: spicedb-alt-up
+
 relations-api-up:
 	./spicedb/start-relations-api.sh
 .PHONY: relations-api-up

--- a/docker-compose-alt.yaml
+++ b/docker-compose-alt.yaml
@@ -1,0 +1,76 @@
+services:
+  relations-api:
+    image: "quay.io/cloudservices/kessel-relations:latest"
+    environment:
+      - "SPICEDB_PRESHARED=${SPICEDB_GRPC_PRESHARED_KEY}"
+      - "SPICEDB_SCHEMA_FILE=/schema_file"
+      # - "SPICEDB_PRESHARED_FILE=/run/secrets/spicedb_pre_shared"
+      - "SPICEDB_ENDPOINT=spicedb:50051"
+    build:
+      dockerfile: Dockerfile
+    profiles: ["relations-api"]
+    secrets:
+      - spicedb_pre_shared
+    configs:
+      - schema_file
+    restart: "always"
+    ports:
+      - "8000:8000"
+      - "9000:9000"
+    networks:
+      - kessel
+
+  spicedb:
+    image: "authzed/spicedb"
+    command: "serve"
+    restart: "always"
+    ports:
+      - "8080:8080"
+      - "9090:9090"
+      - "50051:50051"
+    environment:
+      - "SPICEDB_GRPC_PRESHARED_KEY=${SPICEDB_GRPC_PRESHARED_KEY}"
+      - "SPICEDB_DATASTORE_ENGINE=postgres"
+      - "SPICEDB_DATASTORE_CONN_URI=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@database:5433/spicedb?sslmode=disable"
+    depends_on:
+      - "migrate"
+    networks:
+      - kessel
+
+  migrate:
+    image: "authzed/spicedb"
+    command: "migrate head"
+    restart: "on-failure"
+    environment:
+      - "SPICEDB_DATASTORE_ENGINE=postgres"
+      - "SPICEDB_DATASTORE_CONN_URI=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@database:5433/spicedb?sslmode=disable"
+    depends_on:
+      - "database"
+    networks:
+      - kessel
+
+  database:
+    image: "postgres"
+    command: -c track_commit_timestamp=on -p 5433
+    ports:
+      - "5433:5433"
+    environment:
+      - "POSTGRES_PASSWORD=${POSTGRES_PASSWORD}"
+      - "POSTGRES_DB=${POSTGRES_DBNAME}"
+    networks:
+      - kessel
+
+configs:
+  spicedb_pre_shared:
+    environment: "SPICEDB_GRPC_PRESHARED_KEY"
+  schema_file:
+    file: deploy/schema.zed
+
+secrets:
+  spicedb_pre_shared:
+    file: ./.secrets/local-spicedb-secret
+
+networks:
+  kessel:
+    name: kessel
+    external: true

--- a/docs/ephemeral-testing.md
+++ b/docs/ephemeral-testing.md
@@ -5,6 +5,7 @@ You'll need:
 1) Bonfire
 2) Podman/Docker
 3) Credentials to login to Quay.io (can be your personal credentials or a [Robot Account](https://docs.quay.io/glossary/robot-accounts.html) if desired)
+4) A public Quay repo to push your image to
 
 **tl;dr**
 1) Make your changes
@@ -65,11 +66,24 @@ In the output you'll see where bonfire detects your settings for this app and co
 
 ## Building Container images for testing
 
-Building your own container image to test with is easy, you just need a public quay repo to push to and consume from
+Building your own container image to test with is easy, you just need a **public** quay repo to push to and consume from. These images are designed to be consumed in a cluster.
+
+> Note: If your Quay repo is not public, the cluster will not be able to pull the image. By default, when you push an image to Quay for the first time, it will create the repo for you, but it is set to private by default. This can be changed by navigating to the repo in Quay --> Settings --> Repository Visibility --> Make Public
+
+> Another Note: The process is slightly different for Mac to encompass those using ARM laptops. Using the `build-push-minimal` make target ensures the image is built for Linux/AMD64 to ensure it can run on clusters but may not be ideal for running locally for those on ARM systems.
+
 
 **To build the image on Linux:**
 1) Set the image repo for where the image should be pushed to: `export IMAGE=quay.io/my-repo/relations-api`
-2) Set your  Quay.io credentials so your container engine can login to push: `export QUAY_USER=your-username; export QUAY_TOKEN=your-password`
+2) Set your  Quay.io credentials so your container engine can login to push:
+
+```shell
+export QUAY_USER=your-quay-username
+export QUAY_TOKEN=your-quay-password
+export RH_REGISTRY_USER=your-redhat-registry-user
+export RH_REGISTRY_TOKEN=your-redhat-registry-token
+```
+
 3) Build and push the image: `make docker-build-push`
 
 **On Mac:**

--- a/docs/local-testing-w-notifications.md
+++ b/docs/local-testing-w-notifications.md
@@ -1,0 +1,45 @@
+# Running Notifications + Relations + Inventory using Local Built Binaries
+
+### Running Relations:
+```shell
+# Start up SpiceDB Alt -- uses a different postgres port to avoid conflicts with notifications
+make spicedb-alt-up
+
+# Start relations
+make run
+```
+
+### Running Inventory:
+The process to run Inventory locally can be found in Inventory API's [README](https://github.com/project-kessel/inventory-api?tab=readme-ov-file#kessel-inventory--kessel-relations-using-built-binaries)
+
+By default, Inventory will leverage a SQLite database and create a local db file called `inventory.db`. If you wish to use postgres, you'll need a postgres database running and the config file used in the above doc would need to be updated. An example of configuring Inventory API for postgres can be found [HERE](https://github.com/project-kessel/inventory-api/blob/b19bc4cef8570b8e34f85336067a0b48f9dcf910/inventory-api-compose.yaml#L19)
+
+### Running Notifications
+
+> NOTE: During the clean and install step tests are run that may not work if you do not have Docker -- YMMV
+
+```shell
+# Spin up the Notifications DB
+podman run --name notifications_db --detach -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=notifications -p 5432:5432 docker.io/postgres:latest -c log_statement=all
+
+# Clean, Compile, Test, and Install
+./mvnw clean install
+
+# OR to skip tests (takes about 15 mins)
+./mvnw clean install -Dmaven.test.skip
+
+# Run the Notifications Service
+./mvnw clean quarkus:dev -Dnotifications.use-default-template=true -Dnotifications.kessel-inventory.enabled=true -Dnotifications.kessel-relations.enabled=true -pl :notifications-backend
+```
+
+### Cleanup!
+```shell
+# To kill notifications, enter `q` in the running window to shut it down
+# To kill inventory and relations, use whatever fun killing technique you like!
+
+# Teardown SpiceDB
+make spicedb-down
+
+# Teardown Notifications DB
+podman stop notifications_db && podman rm notifications_db
+```

--- a/spicedb/start-spicedb-alt-port.sh
+++ b/spicedb/start-spicedb-alt-port.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+# Function to check if a command is available
+source ./spicedb/check_docker_podman.sh
+NETWORK_CHECK=$(${DOCKER} network ls --filter name=kessel --format json)
+if [[ -z "${NETWORK_CHECK}" || "${NETWORK_CHECK}" == "[]" ]]; then ${DOCKER} network create kessel; fi
+${DOCKER} compose --env-file ./spicedb/.env -f ./docker-compose-alt.yaml up -d


### PR DESCRIPTION
### PR Template:

## Describe your changes

* Adds an alternate SpiceDB compose setup that uses a different postgres since everything wants to use the default port
* Adds related make target for spinning that up
* Adds doc on running notifications + inventory + relations locally using binaries and compose

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

