### PR TITLE
Update curl command in local kind setup to match current signatures

### DIFF
--- a/spicedb-kind-setup/setup.sh
+++ b/spicedb-kind-setup/setup.sh
@@ -68,5 +68,5 @@ kubectl get ingresses.networking.k8s.io -n spicedb
 
 echo "Relations - Write(POST) - Sample CURL request"
 echo ""
-JSON_DATA='{ "tuples": [{"resource": {"type": {"type": "group"},"id": "bob_club2"},"relation": "member","subject": {"subject": {"type": {"type": "user"},"id": "bob2"}}}]}'
+JSON_DATA='{"tuples":[{"resource":{"id":"bob_club","type":{"name":"group","namespace":"rbac"}},"relation":"member","subject":{"subject":{"id":"bob","type":{"name":"principal","namespace":"rbac"}}}}]}'
 echo "curl -v http://relationships.127.0.0.1.nip.io:8000/api/authz/v1beta1/tuples -H 'Content-Type: application/json' -d '$JSON_DATA'"


### PR DESCRIPTION
### PR Template:

## Describe your changes
The write relations call at the end of the kind setup was causing the following error due to not passing a namespace value:

```{"code":400,"reason":"VALIDATOR","message":"validation error:\n - tuples[0].resource.type.namespace: value length must be at least 1 characters [string.min_len]\n - tuples[0].resource.type.name: value length must be at least 1 characters [string.min_len]\n - tuples[0].subject.subject.type.namespace: value length must be at least 1 characters [string.min_len]\n - tuples[0].subject.subject.type.name: value length must be at least 1 characters [string.min_len]","metadata":{}}[root@cyang1 relations-api]#```

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

