### PR TITLE
Patch ephemeral deployment to include quantization interval & staleness

### DIFF
--- a/build_push_minimal.sh
+++ b/build_push_minimal.sh
@@ -11,6 +11,6 @@ if [[ -z "$QUAY_REPO_RELATIONS" ]]; then
 fi
 IMAGE_TAG=$(git rev-parse --short=7 HEAD)
 
-source ./scripts/check_docker_podman.sh
+source ./spicedb/check_docker_podman.sh
 ${DOCKER} build --platform linux/amd64 --build-arg TARGETARCH=amd64 -t "${QUAY_REPO_RELATIONS}:${IMAGE_TAG}" -f ./Dockerfile
 ${DOCKER} push "${QUAY_REPO_RELATIONS}:${IMAGE_TAG}"

--- a/deploy/kessel-relations.yaml
+++ b/deploy/kessel-relations.yaml
@@ -137,6 +137,11 @@ objects:
                     limits:
                       memory: "256Mi"
                       cpu: "100m"
+                  env:
+                    - name: SPICEDB_DATASTORE_REVISION_QUANTIZATION_INTERVAL
+                      value: ${SPICEDB_QUANTIZATION_INTERVAL}
+                    - name: SPICEDB_DATASTORE_REVISION_QUANTIZATION_MAX_STALENESS_PERCENT
+                      value: ${SPICEDB_QUANTIZATION_STALENESS_PERCENT}
   - apiVersion: cloud.redhat.com/v1alpha1
     kind: ClowdApp
     metadata:
@@ -203,3 +208,9 @@ parameters:
   - description: SpiceDB Image
     name: SPICEDB_IMAGE
     value: quay.io/redhat-services-prod/project-kessel-tenant/kessel-relations/spicedb:latest
+  - description: SpiceDB quantization interval in seconds
+    name: SPICEDB_QUANTIZATION_INTERVAL
+    value: '10s'
+  - description: SpiceDB quantization max staleness percent (float)
+    name: SPICEDB_QUANTIZATION_STALENESS_PERCENT
+    value: '1.0'


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Adds `SPICEDB_DATASTORE_REVISION_QUANTIZATION_INTERVAL` and `SPICEDB_DATASTORE_REVISION_QUANTIZATION_MAX_STALENESS_PERCENT` to ephemeral deploy file.
- - Default values equivalent to stage, for better testing.
- `build_push_minimal.sh` script was calling the wrong directory to check if docker/podman is installed.

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

