### PR TITLE
updates config to volume mount to support podman and selinux

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,8 +11,8 @@ services:
     profiles: ["relations-api"]
     secrets:
       - spicedb_pre_shared
-    configs:
-      - schema_file
+    volumes:
+      - ./deploy/schema.zed:/schema_file:ro,z
     restart: "always"
     ports:
       - "8000:8000"
@@ -63,8 +63,6 @@ services:
 configs:
   spicedb_pre_shared:
     environment: "SPICEDB_GRPC_PRESHARED_KEY"
-  schema_file:
-    file: deploy/schema.zed
 
 secrets:
   spicedb_pre_shared:


### PR DESCRIPTION
### PR Template:

## Describe your changes

changes docker compose setup from using `configs` for mounting the schema file to using `volumes`.  On systems running selinux, using `configs` causes permissions errors reading the schema file which causes relations to fail

```shell
ERROR:
  Code: Unknown
  Message: error creating tuples: failed to load schema file: open /schema_file: permission denied
```
 Using volume mount, we can add the extra selinux mount setting to ensure contexts are relabeled granting permissions
 
 >The z option tells Docker that two containers share the volume content. As a result, Docker labels the content with a shared content label. Shared volume labels allow all containers to read/write content.

Validation:
```shell
$ MESSAGE='{"filter":{"resource_id":"bob_club","resource_type":"group","resource_namespace":"rbac","relation":"member","subject_filter":{"subject_type":"principal","subject_namespace":"rbac","subject_id":"bob"}}}'
[anatale@fedora-csb relations-api]$ MESSAGE='{"tuples":[{"resource":{"id":"bob_club","type":{"name":"group","namespace":"rbac"}},"relation":"member","subject":{"subject":{"id":"bob","type":{"name":"principal","namespace":"rbac"}}}}]}'

$ grpcurl -plaintext -d $MESSAGE \
    localhost:9000 \
    kessel.relations.v1beta1.KesselTupleService.CreateTuples
{
  "consistencyToken": {
    "token": "GgYKBENKVUg="
  }
}

$ podman exec -it relations-api-relations-api-1 ls -l schema_file
-rw-r--r--. 1 root root 1151 May 13 20:45 schema_file

$ podman exec -it relations-api-relations-api-1 ls -lZ schema_file
-rw-r--r--. 1 root root system_u:object_r:container_file_t:s0 1151 May 13 20:45 schema_file


# note, without the :z, the above file would show no permissions which was the root cause of issue
# it would look like
$ ls -l schema_file
-??????????   ? ?    ?      ?            ? schema_file
```

## Summary by Sourcery

Enhancements:
- Replace Compose configs with a bind volume for the schema file and add the :z option to ensure proper SELinux labeling and avoid permission errors under Podman