### PR TITLE
Update protovalidate pkg to latest release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,10 @@ go 1.23.6
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-20250425153114-8976f5be98c1.1
+	buf.build/go/protovalidate v0.12.0
 	github.com/MicahParks/keyfunc/v3 v3.4.0
 	github.com/authzed/authzed-go v1.4.0
 	github.com/authzed/grpcutil v0.0.0-20240123194739-2ea1e3d2d98b
-	github.com/bufbuild/protovalidate-go v0.10.0
 	github.com/go-kratos/kratos/v2 v2.8.4
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/google/wire v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-20250425153114-8976f5be98c1.1 h1:YhMSc48s25kr7kv31Z8vf7sPUIq5YJva9z1mn/hAt0M=
 buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-20250425153114-8976f5be98c1.1/go.mod h1:avRlCjnFzl98VPaeCtJ24RrV/wwHFzB8sWXhj26+n/U=
+buf.build/go/protovalidate v0.12.0 h1:4GKJotbspQjRCcqZMGVSuC8SjwZ/FmgtSuKDpKUTZew=
+buf.build/go/protovalidate v0.12.0/go.mod h1:q3PFfbzI05LeqxSwq+begW2syjy2Z6hLxZSkP1OH/D0=
 cel.dev/expr v0.23.1 h1:K4KOtPCJQjVggkARsjG9RWXP6O4R73aHeJMa/dmCQQg=
 cel.dev/expr v0.23.1/go.mod h1:hLPLo1W4QUmuYdA72RBX06QTs6MXw941piREPl3Yfiw=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=

--- a/internal/server/grpc.go
+++ b/internal/server/grpc.go
@@ -1,7 +1,7 @@
 package server
 
 import (
-	"github.com/bufbuild/protovalidate-go"
+	"buf.build/go/protovalidate"
 	"github.com/go-kratos/kratos/v2/log"
 	"github.com/go-kratos/kratos/v2/middleware/auth/jwt"
 	"github.com/go-kratos/kratos/v2/middleware/logging"

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -3,8 +3,8 @@ package server
 import (
 	"context"
 
+	"buf.build/go/protovalidate"
 	"github.com/MicahParks/keyfunc/v3"
-	"github.com/bufbuild/protovalidate-go"
 	"github.com/go-kratos/kratos/v2/log"
 	"github.com/go-kratos/kratos/v2/middleware/auth/jwt"
 	"github.com/go-kratos/kratos/v2/middleware/logging"

--- a/internal/server/middleware/validation.go
+++ b/internal/server/middleware/validation.go
@@ -3,7 +3,7 @@ package middleware
 import (
 	"context"
 
-	"github.com/bufbuild/protovalidate-go"
+	"buf.build/go/protovalidate"
 	"github.com/go-kratos/kratos/v2/errors"
 	"github.com/go-kratos/kratos/v2/middleware"
 	"google.golang.org/grpc"

--- a/internal/server/middleware/validation_test.go
+++ b/internal/server/middleware/validation_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/bufbuild/protovalidate-go"
+	"buf.build/go/protovalidate"
 	"github.com/project-kessel/relations-api/api/kessel/relations/v1beta1"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"


### PR DESCRIPTION
### PR Template:

## Describe your changes

- As found while investigating https://github.com/project-kessel/inventory-api/pull/584, `http://github.com/bufbuild/protovalidate-go` has been moved to `buf.build/go/protovalidate`
- This has been possibly preventing dependabot and konflux bot from updating the package as we are now 2 versions behind latest.
- Updating now should forgo us from having any discrepancies between the generated proto code and validation

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

## Summary by Sourcery

Upgrade the protovalidate dependency to v0.12.0 and realign import paths to the new buf.build/go/protovalidate module

Enhancements:
- Replace the deprecated github.com/bufbuild/protovalidate-go package with buf.build/go/protovalidate v0.12.0
- Update import statements across validation middleware and tests to reference the new module path

Build:
- Remove the old protovalidate-go dependency and add buf.build/go/protovalidate v0.12.0 in go.mod

Tests:
- Adjust validation tests to import from buf.build/go/protovalidate