### PR TITLE
RHCLOUD-41228: Update Rbac sync excessive dashboard to match alert

### DIFF
--- a/dashboards/grafana-dashboard-kessel-relations-api-data-sync.configmap.yaml
+++ b/dashboards/grafana-dashboard-kessel-relations-api-data-sync.configmap.yaml
@@ -105,7 +105,7 @@ data:
               "refId": "A"
             }
           ],
-          "title": "RBAC -> Relations API: Excessive lag events (>0.02 rate diff for 10m))",
+          "title": "RBAC -> Relations API: Excessive lag events (>0.02 rate diff for 10m)",
           "type": "state-timeline"
         },
         {

--- a/dashboards/grafana-dashboard-kessel-relations-api-data-sync.configmap.yaml
+++ b/dashboards/grafana-dashboard-kessel-relations-api-data-sync.configmap.yaml
@@ -97,7 +97,7 @@ data:
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "min_over_time((sum(rate(relations_replication_event_total[3m])) - sum(rate(kafka_connect_sink_task_sink_record_send_total{connector=\"relations-sink-connector\"}[3m])))[1m:15s]) > 0.01",
+              "expr": "min_over_time((sum(rate(relations_replication_event_total[10m])) - sum(rate(kafka_connect_sink_task_sink_record_send_total{connector=\"relations-sink-connector\"}[10m])))[1m:15s]) > 0.02",
               "format": "time_series",
               "instant": false,
               "legendFormat": "__auto",
@@ -105,7 +105,7 @@ data:
               "refId": "A"
             }
           ],
-          "title": "RBAC -> Relations API: Excessive lag events (>0.01 rate diff for 1m))",
+          "title": "RBAC -> Relations API: Excessive lag events (>0.02 rate diff for 10m))",
           "type": "state-timeline"
         },
         {
@@ -160,7 +160,7 @@ data:
                   },
                   {
                     "color": "red",
-                    "value": 0.01
+                    "value": 0.02
                   }
                 ]
               }
@@ -193,14 +193,14 @@ data:
                 "uid": "${Datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(rate(relations_replication_event_total[3m])) - sum(rate(kafka_connect_sink_task_sink_record_send_total{connector=\"relations-sink-connector\"}[3m]))",
+              "expr": "sum(rate(relations_replication_event_total[10m])) - sum(rate(kafka_connect_sink_task_sink_record_send_total{connector=\"relations-sink-connector\"}[10m]))",
               "instant": false,
               "legendFormat": "__auto",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "RBAC -> Relations API: Replication event creation rate minus sink rate [3m]",
+          "title": "RBAC -> Relations API: Replication event creation rate minus sink rate [10m]",
           "type": "timeseries"
         },
         {
@@ -752,7 +752,7 @@ data:
       "timezone": "browser",
       "title": "Kessel  - Relations API data sync",
       "uid": "ce3ty1vy1gpvkd",
-      "version": 5,
+      "version": 6,
       "weekStart": ""
     }
 kind: ConfigMap


### PR DESCRIPTION
### PR Template:

## Describe your changes

- Updates the relevant dashboard panels to reflect changes made already in the RbacRelationsApiReplicationFailure alert.

## Ticket reference (if applicable)
Fixes #RHCLOUD-41228

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

## Summary by Sourcery

Align Grafana dashboard panels for RBAC -> Relations API data sync with the updated RbacRelationsApiReplicationFailure alert settings

Enhancements:
- Adjust state-timeline and timeseries panel queries to use a 10m window instead of 3m
- Update threshold value from 0.01 to 0.02 in relevant panels
- Update panel titles to reflect the new threshold and time window
- Bump Grafana dashboard config version from 5 to 6