### PR TITLE
updates go version to latest available with go-toolset

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,6 @@ RUN make build
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1752587672
 
-# installs RHEL fork of go to be able to validate with go tools for FIPS -- likely not needed long term
-RUN microdnf install -y go-toolset
 RUN mkdir /config
 
 COPY --from=builder /workspace/bin/kessel-relations /usr/local/bin/

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/project-kessel/relations-api
 
 // Take care to bump versions with FIPS compliance in mind
-go 1.23.9
+go 1.24.4
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-20250625184727-c923a0c2a132.1


### PR DESCRIPTION
### PR Template:

## Describe your changes

* updates go.mod for latest available go version in go-toolset (1.24.4)
* removes go-toolset install from final image to reduce CVE issues (was only there for FIPS validation, not needed right now)

## Summary by Sourcery

Update Go toolset and streamline the Docker image by upgrading the Go version and removing the unnecessary go-toolset installation.

Enhancements:
- Bump Go version in go.mod to 1.24.4
- Remove go-toolset installation from final Docker image