### PR TITLE
Updates go.mod for latest available go version provided by go-toolset…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,7 @@ RUN make build
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1752587672
 
-# installs RHEL fork of go to be able to validate with go tools for FIPS -- likely not needed long term
-RUN microdnf install -y go-toolset
+
 RUN mkdir /config
 
 COPY --from=builder /workspace/bin/kessel-relations /usr/local/bin/

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/project-kessel/relations-api
 
 // Take care to bump versions with FIPS compliance in mind
-go 1.23.9
+go 1.24.4
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.6-20250625184727-c923a0c2a132.1


### PR DESCRIPTION
… (go 1.24.4)

- Removes adding go-toolset from the final inventory container to reduce any CVE potential (we dont need it for now, it was for validating FIPS)

### PR Template:

## Describe your changes

- ...

## Ticket reference (if applicable)
Fixes #

## Checklist

* [ ] Are the agreed upon acceptance criteria fulfilled?

* [ ] Was the 4-eye-principle applied? (async PR review, pairing, ensembling)

* [ ] Do your changes have passing automated tests and sufficient observability?

* [ ] Are the work steps you introduced repeatable by others, either through automation or documentation?
  * [ ] If automation is possible but not done due to other constraints, a ticket to the tech debt sprint is added
  * [ ] An SOP (Standard Operating Procedure) was created

* [ ] The Changes were automatically built, tested, and  - if needed, behind a feature flag - deployed to our production environment. (**Please check this when the new deployment is done and you could verify it.**)

* [ ] Are the agreed upon coding/architectural practices applied?

* [ ] Are security needs fullfilled? (e.g. no internal URL)

* [ ] Is the corresponding Ticket in the right state? (should be on "review" now, put to done when this change made it to production)

* [ ] For changes to the public API / code dependencies: Was the whole team (or a sufficient amount of ppl) able to review?

## Summary by Sourcery

Upgrade Go version to 1.24.4 and remove go-toolset from the Docker build

Enhancements:
- Bump Go version in go.mod from 1.23.9 to 1.24.4
- Remove go-toolset installation from Dockerfile to reduce CVE exposure