### PR TITLE
RHCLOUD-48764: implements SEC-REQ-MON-1 security logging requirements

### DIFF
--- a/cmd/kessel-relations/main.go
+++ b/cmd/kessel-relations/main.go
@@ -84,11 +84,26 @@ func main() {
 	//	bc.Data.SpiceDb.Token = preshared
 	//}
 
-	app, cleanup, err := wireApp(bc.Server, bc.Data, createLogger(bc.Server))
+	logger := createLogger(bc.Server)
+
+	app, cleanup, err := wireApp(bc.Server, bc.Data, logger)
 	if err != nil {
 		panic(fmt.Errorf("error initializing application (via wire): %w", err))
 	}
 	defer cleanup()
+
+	// Service startup - SEC-MON-REQ-1 compliance (EOI-5 process_status)
+	log.NewHelper(logger).Infow(
+		"msg", "Service starting",
+		"action", "STARTUP",
+		"resource_type", "service",
+		"resource_id", Name,
+		"outcome", "success",
+		"service_version", Version,
+		"auth_enabled", bc.Server.Auth.EnableAuth,
+		"grpc_addr", bc.Server.Grpc.Addr,
+		"http_addr", bc.Server.Http.Addr,
+	)
 
 	// start and wait for stop signal
 	if err := app.Run(); err != nil {

--- a/internal/server/grpc.go
+++ b/internal/server/grpc.go
@@ -66,12 +66,14 @@ func NewGRPCServer(c *conf.Server, relations *service.RelationshipsService, heal
 		}
 
 		unaryMiddleware = append(unaryMiddleware,
+			auth.AuthFailureLoggingMiddleware(logger),
 			selector.Server(jwt.Server(jwks.Keyfunc,
 				jwt.WithSigningMethod(jwtv5.SigningMethodRS256))).
 				Match(NewWhiteListMatcher).
 				Build(),
 		)
 		streamingMiddleware = append(streamingMiddleware, auth.StreamAuthInterceptor(
+			logger,
 			jwks.Keyfunc,
 			auth.WithSigningMethod(jwtv5.SigningMethodRS256)))
 	}

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -17,6 +17,7 @@ import (
 	v1beta1 "github.com/project-kessel/relations-api/api/kessel/relations/v1beta1"
 	"github.com/project-kessel/relations-api/internal/conf"
 	"github.com/project-kessel/relations-api/internal/server/middleware"
+	"github.com/project-kessel/relations-api/internal/server/middleware/auth"
 	"github.com/project-kessel/relations-api/internal/service"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -54,6 +55,7 @@ func NewHTTPServer(c *conf.Server, relationships *service.RelationshipsService, 
 			return nil, err
 		}
 		opts = append(opts, http.Middleware(
+			auth.AuthFailureLoggingMiddleware(logger),
 			selector.Server(
 				jwt.Server(
 					jwks.Keyfunc,

--- a/internal/server/middleware/auth/auth.go
+++ b/internal/server/middleware/auth/auth.go
@@ -175,18 +175,18 @@ func AuthFailureLoggingMiddleware(logger log.Logger) kratosMiddleware.Middleware
 }
 
 func jwtErrorReason(err error) string {
-	switch {
-	case jwt.ErrMissingKeyFunc.Is(err):
+	switch err {
+	case jwt.ErrMissingKeyFunc:
 		return "missing_key_func"
-	case jwt.ErrMissingJwtToken.Is(err):
+	case jwt.ErrMissingJwtToken:
 		return "missing_token"
-	case jwt.ErrTokenInvalid.Is(err):
+	case jwt.ErrTokenInvalid:
 		return "token_invalid"
-	case jwt.ErrTokenExpired.Is(err):
+	case jwt.ErrTokenExpired:
 		return "token_expired"
-	case jwt.ErrTokenParseFail.Is(err):
+	case jwt.ErrTokenParseFail:
 		return "token_parse_failed"
-	case jwt.ErrUnSupportSigningMethod.Is(err):
+	case jwt.ErrUnSupportSigningMethod:
 		return "unsupported_signing_method"
 	default:
 		return ""

--- a/internal/server/middleware/auth/auth.go
+++ b/internal/server/middleware/auth/auth.go
@@ -2,12 +2,16 @@ package auth
 
 import (
 	"context"
+	"strings"
+
 	"github.com/go-kratos/kratos/v2/errors"
+	"github.com/go-kratos/kratos/v2/log"
+	kratosMiddleware "github.com/go-kratos/kratos/v2/middleware"
 	"github.com/go-kratos/kratos/v2/middleware/auth/jwt"
+	"github.com/go-kratos/kratos/v2/transport"
 	jwtv5 "github.com/golang-jwt/jwt/v5"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
-	"strings"
 )
 
 type authKey struct{}
@@ -48,30 +52,47 @@ func WithSigningMethod(signingMethod jwtv5.SigningMethod) AuthOption {
 }
 
 // StreamAuthInterceptor is a gRPC stream server interceptor for JWT authentication.
-func StreamAuthInterceptor(keyFunc jwtv5.Keyfunc, opts ...AuthOption) grpc.StreamServerInterceptor {
+func StreamAuthInterceptor(logger log.Logger, keyFunc jwtv5.Keyfunc, opts ...AuthOption) grpc.StreamServerInterceptor {
 	o := &authOptions{
 		signingMethod: jwtv5.SigningMethodRS256,
 	}
 	for _, opt := range opts {
 		opt(o)
 	}
+
+	// Authentication failure - SEC-MON-REQ-1 compliance (EOI-7 invalid_login, EOI-8 authorization_failure)
+	logAuthFailure := func(ctx context.Context, operation, reason string) {
+		log.NewHelper(log.WithContext(ctx, logger)).Warnw(
+			"msg", "Authentication failed",
+			"action", "AUTHENTICATE",
+			"resource_type", "api_endpoint",
+			"resource_id", operation,
+			"outcome", "failure",
+			"reason", reason,
+		)
+	}
+
 	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 		var newCtx context.Context
 		var err error
 		newCtx = ss.Context()
 		if keyFunc == nil {
+			logAuthFailure(newCtx, info.FullMethod, "missing_key_func")
 			return jwt.ErrMissingKeyFunc
 		}
 		md, ok := metadata.FromIncomingContext(newCtx)
 		if !ok {
+			logAuthFailure(newCtx, info.FullMethod, "missing_token")
 			return jwt.ErrMissingJwtToken
 		}
 		authHeader, ok := md[authorizationKey]
 		if !ok || len(authHeader) == 0 {
+			logAuthFailure(newCtx, info.FullMethod, "missing_token")
 			return jwt.ErrMissingJwtToken
 		}
 		auths := strings.SplitN(authHeader[0], " ", 2)
 		if len(auths) != 2 || !strings.EqualFold(auths[0], bearerWord) {
+			logAuthFailure(newCtx, info.FullMethod, "missing_token")
 			return jwt.ErrMissingJwtToken
 		}
 		jwtToken := auths[1]
@@ -85,17 +106,22 @@ func StreamAuthInterceptor(keyFunc jwtv5.Keyfunc, opts ...AuthOption) grpc.Strea
 		}
 		if err != nil {
 			if errors.Is(err, jwtv5.ErrTokenMalformed) || errors.Is(err, jwtv5.ErrTokenUnverifiable) {
+				logAuthFailure(newCtx, info.FullMethod, "token_invalid")
 				return jwt.ErrTokenInvalid
 			}
 			if errors.Is(err, jwtv5.ErrTokenNotValidYet) || errors.Is(err, jwtv5.ErrTokenExpired) {
+				logAuthFailure(newCtx, info.FullMethod, "token_expired")
 				return jwt.ErrTokenExpired
 			}
+			logAuthFailure(newCtx, info.FullMethod, "token_parse_failed")
 			return jwt.ErrTokenParseFail
 		}
 		if !tokenInfo.Valid {
+			logAuthFailure(newCtx, info.FullMethod, "token_invalid")
 			return jwt.ErrTokenInvalid
 		}
 		if tokenInfo.Method != o.signingMethod {
+			logAuthFailure(newCtx, info.FullMethod, "unsupported_signing_method")
 			return jwt.ErrUnSupportSigningMethod
 		}
 		newCtx = NewContext(newCtx, tokenInfo.Claims)
@@ -120,4 +146,49 @@ func NewContext(ctx context.Context, info jwtv5.Claims) context.Context {
 func FromContext(ctx context.Context) (jwtv5.Claims, bool) {
 	claims, ok := ctx.Value(authKey{}).(jwtv5.Claims)
 	return claims, ok
+}
+
+// AuthFailureLoggingMiddleware logs JWT authentication failures for unary RPCs (SEC-MON-REQ-1 compliance).
+func AuthFailureLoggingMiddleware(logger log.Logger) kratosMiddleware.Middleware {
+	return func(handler kratosMiddleware.Handler) kratosMiddleware.Handler {
+		return func(ctx context.Context, req any) (any, error) {
+			resp, err := handler(ctx, req)
+			if err != nil {
+				if reason := jwtErrorReason(err); reason != "" {
+					operation := "unknown"
+					if tr, ok := transport.FromServerContext(ctx); ok {
+						operation = tr.Operation()
+					}
+					log.NewHelper(log.WithContext(ctx, logger)).Warnw(
+						"msg", "Authentication failed",
+						"action", "AUTHENTICATE",
+						"resource_type", "api_endpoint",
+						"resource_id", operation,
+						"outcome", "failure",
+						"reason", reason,
+					)
+				}
+			}
+			return resp, err
+		}
+	}
+}
+
+func jwtErrorReason(err error) string {
+	switch {
+	case jwt.ErrMissingKeyFunc.Is(err):
+		return "missing_key_func"
+	case jwt.ErrMissingJwtToken.Is(err):
+		return "missing_token"
+	case jwt.ErrTokenInvalid.Is(err):
+		return "token_invalid"
+	case jwt.ErrTokenExpired.Is(err):
+		return "token_expired"
+	case jwt.ErrTokenParseFail.Is(err):
+		return "token_parse_failed"
+	case jwt.ErrUnSupportSigningMethod.Is(err):
+		return "unsupported_signing_method"
+	default:
+		return ""
+	}
 }

--- a/internal/server/middleware/auth/auth_test.go
+++ b/internal/server/middleware/auth/auth_test.go
@@ -3,13 +3,50 @@ package auth
 import (
 	"context"
 	"io"
+	"sync"
 	"testing"
 
 	"github.com/go-kratos/kratos/v2/log"
 	"github.com/go-kratos/kratos/v2/middleware/auth/jwt"
 	"github.com/go-kratos/kratos/v2/transport"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+type logEntry struct {
+	level   log.Level
+	keyvals []any
+}
+
+// captureLogger records every Log call for assertion in tests.
+type captureLogger struct {
+	mu      sync.Mutex
+	entries []logEntry
+}
+
+func (c *captureLogger) Log(level log.Level, keyvals ...any) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries = append(c.entries, logEntry{level: level, keyvals: keyvals})
+	return nil
+}
+
+func (c *captureLogger) all() []logEntry {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.entries
+}
+
+// keyvalMap converts a flat key-value slice into a map for field assertions.
+func keyvalMap(keyvals []any) map[string]any {
+	m := make(map[string]any, len(keyvals)/2)
+	for i := 0; i+1 < len(keyvals); i += 2 {
+		if k, ok := keyvals[i].(string); ok {
+			m[k] = keyvals[i+1]
+		}
+	}
+	return m
+}
 
 // mockTransporter satisfies transport.Transporter for injecting operation names in tests.
 type mockTransporter struct {
@@ -58,6 +95,8 @@ func TestAuthFailureLoggingMiddleware_PassesThroughNonJwtError(t *testing.T) {
 func TestAuthFailureLoggingMiddleware_LogsAndPassesThroughJwtErrors(t *testing.T) {
 	t.Parallel()
 
+	const operation = "/kessel.relations.v1beta1.KesselTupleService/CreateTuples"
+
 	jwtErrors := []error{
 		jwt.ErrMissingJwtToken,
 		jwt.ErrTokenInvalid,
@@ -67,19 +106,35 @@ func TestAuthFailureLoggingMiddleware_LogsAndPassesThroughJwtErrors(t *testing.T
 		jwt.ErrMissingKeyFunc,
 	}
 
-	logger := log.NewStdLogger(io.Discard)
-	m := AuthFailureLoggingMiddleware(logger)
-
 	for _, jwtErr := range jwtErrors {
 		t.Run(jwtErr.Error(), func(t *testing.T) {
 			t.Parallel()
+
+			cl := &captureLogger{}
+			m := AuthFailureLoggingMiddleware(cl)
 
 			handler := func(ctx context.Context, req any) (any, error) {
 				return nil, jwtErr
 			}
 
-			_, err := m(handler)(ctxWithOperation("/kessel.relations.v1beta1.KesselTupleService/CreateTuples"), nil)
+			_, err := m(handler)(ctxWithOperation(operation), nil)
+
+			// Error is passed through unchanged.
 			assert.Equal(t, jwtErr, err)
+
+			// Exactly one log entry must have been emitted.
+			entries := cl.all()
+			require.Len(t, entries, 1)
+
+			entry := entries[0]
+			assert.Equal(t, log.LevelWarn, entry.level)
+
+			fields := keyvalMap(entry.keyvals)
+			assert.Equal(t, "AUTHENTICATE", fields["action"])
+			assert.Equal(t, "api_endpoint", fields["resource_type"])
+			assert.Equal(t, operation, fields["resource_id"])
+			assert.Equal(t, "failure", fields["outcome"])
+			assert.Equal(t, jwtErrorReason(jwtErr), fields["reason"])
 		})
 	}
 }

--- a/internal/server/middleware/auth/auth_test.go
+++ b/internal/server/middleware/auth/auth_test.go
@@ -1,0 +1,110 @@
+package auth
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/go-kratos/kratos/v2/log"
+	"github.com/go-kratos/kratos/v2/middleware/auth/jwt"
+	"github.com/go-kratos/kratos/v2/transport"
+	"github.com/stretchr/testify/assert"
+)
+
+// mockTransporter satisfies transport.Transporter for injecting operation names in tests.
+type mockTransporter struct {
+	operation string
+}
+
+func (m *mockTransporter) Kind() transport.Kind      { return transport.KindGRPC }
+func (m *mockTransporter) Endpoint() string          { return "" }
+func (m *mockTransporter) Operation() string         { return m.operation }
+func (m *mockTransporter) RequestHeader() transport.Header { return nil }
+func (m *mockTransporter) ReplyHeader() transport.Header   { return nil }
+
+func ctxWithOperation(operation string) context.Context {
+	return transport.NewServerContext(context.Background(), &mockTransporter{operation: operation})
+}
+
+func TestAuthFailureLoggingMiddleware_PassesThroughSuccess(t *testing.T) {
+	t.Parallel()
+
+	logger := log.NewStdLogger(io.Discard)
+	m := AuthFailureLoggingMiddleware(logger)
+
+	handler := func(ctx context.Context, req any) (any, error) {
+		return "ok", nil
+	}
+
+	resp, err := m(handler)(ctxWithOperation("/test/Method"), nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "ok", resp)
+}
+
+func TestAuthFailureLoggingMiddleware_PassesThroughNonJwtError(t *testing.T) {
+	t.Parallel()
+
+	logger := log.NewStdLogger(io.Discard)
+	m := AuthFailureLoggingMiddleware(logger)
+
+	handler := func(ctx context.Context, req any) (any, error) {
+		return nil, assert.AnError
+	}
+
+	_, err := m(handler)(ctxWithOperation("/test/Method"), nil)
+	assert.ErrorIs(t, err, assert.AnError)
+}
+
+func TestAuthFailureLoggingMiddleware_LogsAndPassesThroughJwtErrors(t *testing.T) {
+	t.Parallel()
+
+	jwtErrors := []error{
+		jwt.ErrMissingJwtToken,
+		jwt.ErrTokenInvalid,
+		jwt.ErrTokenExpired,
+		jwt.ErrTokenParseFail,
+		jwt.ErrUnSupportSigningMethod,
+		jwt.ErrMissingKeyFunc,
+	}
+
+	logger := log.NewStdLogger(io.Discard)
+	m := AuthFailureLoggingMiddleware(logger)
+
+	for _, jwtErr := range jwtErrors {
+		t.Run(jwtErr.Error(), func(t *testing.T) {
+			t.Parallel()
+
+			handler := func(ctx context.Context, req any) (any, error) {
+				return nil, jwtErr
+			}
+
+			_, err := m(handler)(ctxWithOperation("/kessel.relations.v1beta1.KesselTupleService/CreateTuples"), nil)
+			assert.Equal(t, jwtErr, err)
+		})
+	}
+}
+
+func TestJwtErrorReason(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		err      error
+		expected string
+	}{
+		{"missing_key_func", jwt.ErrMissingKeyFunc, "missing_key_func"},
+		{"missing_token", jwt.ErrMissingJwtToken, "missing_token"},
+		{"token_invalid", jwt.ErrTokenInvalid, "token_invalid"},
+		{"token_expired", jwt.ErrTokenExpired, "token_expired"},
+		{"token_parse_failed", jwt.ErrTokenParseFail, "token_parse_failed"},
+		{"unsupported_signing_method", jwt.ErrUnSupportSigningMethod, "unsupported_signing_method"},
+		{"non_jwt_error", assert.AnError, ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, jwtErrorReason(tc.err))
+		})
+	}
+}

--- a/internal/service/relationships.go
+++ b/internal/service/relationships.go
@@ -37,8 +37,28 @@ func NewRelationshipsService(logger log.Logger, createUseCase *biz.CreateRelatio
 func (s *RelationshipsService) CreateTuples(ctx context.Context, req *pb.CreateTuplesRequest) (*pb.CreateTuplesResponse, error) {
 	resp, err := s.createUsecase.CreateRelationships(ctx, req.Tuples, req.GetUpsert(), req.GetFencingCheck()) //The generated .GetUpsert() defaults to false
 	if err != nil {
+		// Tuple creation failure - SEC-MON-REQ-1 compliance (EOI-1 pii_manipulation, EOI-4 access_manipulation, EOI-11 warnings_or_errors)
+		s.log.WithContext(ctx).Warnw(
+			"msg", "Tuple creation failed",
+			"action", "CREATE",
+			"resource_type", "relationship_tuple",
+			"resource_id", fmt.Sprintf("count:%d", len(req.Tuples)),
+			"outcome", "failure",
+			"principal", extractPrincipal(ctx),
+			"reason", "spicedb_error",
+		)
 		return nil, fmt.Errorf("error creating tuples: %w", err)
 	}
+
+	// Tuple creation - SEC-MON-REQ-1 compliance (EOI-1 pii_manipulation, EOI-4 access_manipulation)
+	s.log.WithContext(ctx).Infow(
+		"msg", "Tuples created",
+		"action", "CREATE",
+		"resource_type", "relationship_tuple",
+		"resource_id", fmt.Sprintf("count:%d", len(req.Tuples)),
+		"outcome", "success",
+		"principal", extractPrincipal(ctx),
+	)
 
 	return &pb.CreateTuplesResponse{ConsistencyToken: resp.GetConsistencyToken()}, nil
 }
@@ -72,26 +92,108 @@ func (s *RelationshipsService) ReadTuples(req *pb.ReadTuplesRequest, conn pb.Kes
 }
 
 func (s *RelationshipsService) DeleteTuples(ctx context.Context, req *pb.DeleteTuplesRequest) (*pb.DeleteTuplesResponse, error) {
+	resourceID := deleteFilterResourceID(req.Filter)
+
 	resp, err := s.deleteUsecase.DeleteRelationships(ctx, req.Filter, req.GetFencingCheck())
 	if err != nil {
+		// Tuple deletion failure - SEC-MON-REQ-1 compliance (EOI-1 pii_manipulation, EOI-4 access_manipulation, EOI-11 warnings_or_errors)
+		s.log.WithContext(ctx).Warnw(
+			"msg", "Tuple deletion failed",
+			"action", "DELETE",
+			"resource_type", "relationship_tuple",
+			"resource_id", resourceID,
+			"outcome", "failure",
+			"principal", extractPrincipal(ctx),
+			"reason", "spicedb_error",
+		)
 		return nil, fmt.Errorf("error deleting tuples: %w", err)
 	}
+
+	// Tuple deletion - SEC-MON-REQ-1 compliance (EOI-1 pii_manipulation, EOI-4 access_manipulation)
+	s.log.WithContext(ctx).Infow(
+		"msg", "Tuples deleted",
+		"action", "DELETE",
+		"resource_type", "relationship_tuple",
+		"resource_id", resourceID,
+		"outcome", "success",
+		"principal", extractPrincipal(ctx),
+	)
 
 	return &pb.DeleteTuplesResponse{ConsistencyToken: resp.GetConsistencyToken()}, nil
 }
 
+func deleteFilterResourceID(filter *pb.RelationTupleFilter) string {
+	if filter == nil {
+		return "filtered"
+	}
+	ns := filter.GetResourceNamespace()
+	rt := filter.GetResourceType()
+	rid := filter.GetResourceId()
+	if ns != "" && rt != "" && rid != "" {
+		return fmt.Sprintf("%s/%s:%s", ns, rt, rid)
+	}
+	if ns != "" && rt != "" {
+		return fmt.Sprintf("%s/%s", ns, rt)
+	}
+	if rt != "" {
+		return rt
+	}
+	return "filtered"
+}
+
 func (s *RelationshipsService) ImportBulkTuples(stream grpc.ClientStreamingServer[pb.ImportBulkTuplesRequest, pb.ImportBulkTuplesResponse]) error {
+	ctx := stream.Context()
 	err := s.importBulkUsecase.ImportBulkTuples(stream)
 	if err != nil {
+		// Bulk tuple import failure - SEC-MON-REQ-1 compliance (EOI-1 pii_manipulation, EOI-4 access_manipulation, EOI-11 warnings_or_errors)
+		s.log.WithContext(ctx).Warnw(
+			"msg", "Bulk tuple import failed",
+			"action", "IMPORT",
+			"resource_type", "relationship_tuple",
+			"resource_id", "bulk_import",
+			"outcome", "failure",
+			"principal", extractPrincipal(ctx),
+			"reason", "import_error",
+		)
 		return fmt.Errorf("error import bulk tuples: %w", err)
 	}
+
+	// Bulk tuple import - SEC-MON-REQ-1 compliance (EOI-1 pii_manipulation, EOI-4 access_manipulation)
+	s.log.WithContext(ctx).Infow(
+		"msg", "Bulk tuples imported",
+		"action", "IMPORT",
+		"resource_type", "relationship_tuple",
+		"resource_id", "bulk_import",
+		"outcome", "success",
+		"principal", extractPrincipal(ctx),
+	)
 	return nil
 }
 
 func (s *RelationshipsService) AcquireLock(ctx context.Context, req *pb.AcquireLockRequest) (*pb.AcquireLockResponse, error) {
 	resp, err := s.acquireLockUsecase.AcquireLock(ctx, req)
 	if err != nil {
+		// Lock acquisition failure - SEC-MON-REQ-1 compliance (EOI-4 access_manipulation, EOI-11 warnings_or_errors)
+		s.log.WithContext(ctx).Warnw(
+			"msg", "Lock acquisition failed",
+			"action", "CREATE",
+			"resource_type", "lock",
+			"resource_id", req.GetLockId(),
+			"outcome", "failure",
+			"principal", extractPrincipal(ctx),
+			"reason", "lock_error",
+		)
 		return nil, fmt.Errorf("error acquiring lock: %w", err)
 	}
+
+	// Lock acquisition - SEC-MON-REQ-1 compliance (EOI-4 access_manipulation)
+	s.log.WithContext(ctx).Infow(
+		"msg", "Lock acquired",
+		"action", "CREATE",
+		"resource_type", "lock",
+		"resource_id", req.GetLockId(),
+		"outcome", "success",
+		"principal", extractPrincipal(ctx),
+	)
 	return resp, nil
 }

--- a/internal/service/security_logging.go
+++ b/internal/service/security_logging.go
@@ -1,0 +1,32 @@
+package service
+
+import (
+	"context"
+
+	kratosJwt "github.com/go-kratos/kratos/v2/middleware/auth/jwt"
+	jwtv5 "github.com/golang-jwt/jwt/v5"
+	localAuth "github.com/project-kessel/relations-api/internal/server/middleware/auth"
+)
+
+func extractPrincipal(ctx context.Context) string {
+	if token, ok := kratosJwt.FromContext(ctx); ok {
+		if sub := extractSub(token); sub != "" {
+			return sub
+		}
+	}
+	if claims, ok := localAuth.FromContext(ctx); ok {
+		if sub := extractSub(claims); sub != "" {
+			return sub
+		}
+	}
+	return ""
+}
+
+func extractSub(claims any) string {
+	if mc, ok := claims.(jwtv5.MapClaims); ok {
+		if sub, ok := mc["sub"].(string); ok {
+			return sub
+		}
+	}
+	return ""
+}

--- a/internal/service/security_logging_test.go
+++ b/internal/service/security_logging_test.go
@@ -1,0 +1,83 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	kratosJwt "github.com/go-kratos/kratos/v2/middleware/auth/jwt"
+	jwtv5 "github.com/golang-jwt/jwt/v5"
+	localAuth "github.com/project-kessel/relations-api/internal/server/middleware/auth"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractPrincipal_KratosJwtContext(t *testing.T) {
+	t.Parallel()
+
+	claims := jwtv5.MapClaims{"sub": "user@example.com"}
+	ctx := kratosJwt.NewContext(context.Background(), claims)
+
+	assert.Equal(t, "user@example.com", extractPrincipal(ctx))
+}
+
+func TestExtractPrincipal_LocalAuthContext(t *testing.T) {
+	t.Parallel()
+
+	claims := jwtv5.MapClaims{"sub": "stream-user@example.com"}
+	ctx := localAuth.NewContext(context.Background(), claims)
+
+	assert.Equal(t, "stream-user@example.com", extractPrincipal(ctx))
+}
+
+func TestExtractPrincipal_KratosJwtTakesPrecedence(t *testing.T) {
+	t.Parallel()
+
+	kratosClaims := jwtv5.MapClaims{"sub": "kratos-user"}
+	localClaims := jwtv5.MapClaims{"sub": "local-user"}
+	ctx := kratosJwt.NewContext(context.Background(), kratosClaims)
+	ctx = localAuth.NewContext(ctx, localClaims)
+
+	assert.Equal(t, "kratos-user", extractPrincipal(ctx))
+}
+
+func TestExtractPrincipal_NoContext(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "", extractPrincipal(context.Background()))
+}
+
+func TestExtractPrincipal_MissingSubClaim(t *testing.T) {
+	t.Parallel()
+
+	claims := jwtv5.MapClaims{"email": "user@example.com"}
+	ctx := kratosJwt.NewContext(context.Background(), claims)
+
+	assert.Equal(t, "", extractPrincipal(ctx))
+}
+
+func TestExtractPrincipal_NonStringSubClaim(t *testing.T) {
+	t.Parallel()
+
+	claims := jwtv5.MapClaims{"sub": 12345}
+	ctx := kratosJwt.NewContext(context.Background(), claims)
+
+	assert.Equal(t, "", extractPrincipal(ctx))
+}
+
+func TestExtractSub_ValidMapClaims(t *testing.T) {
+	t.Parallel()
+
+	claims := jwtv5.MapClaims{"sub": "alice"}
+	assert.Equal(t, "alice", extractSub(claims))
+}
+
+func TestExtractSub_NonMapClaims(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "", extractSub("not-a-claims-object"))
+}
+
+func TestExtractSub_NilClaims(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "", extractSub(nil))
+}


### PR DESCRIPTION
SEC-MON-REQ-1: Add security event logging

Implements security logging compliance for the relations-api service as required by SEC-MON-REQ-1.
* CreateTuples, DeleteTuples, ImportBulkTuples, and AcquireLock now emit a structured security log on both success and failure paths. 
  * The principal field is populated from the JWT sub claim when auth is enabled, and left empty when auth is off. 
  * For DeleteTuples, the resource_id is derived from the filter fields (e.g. rbac/workspace:my-workspace) rather than a generic
  placeholder.
* Authentication failure logging (internal/server/middleware/auth/auth.go, grpc.go, http.go)
  * Streaming RPCs already used a custom StreamAuthInterceptor so auth failure logging was added directly there.
  * Unary RPCs go through the third-party Kratos jwt.Server() middleware which cannot be modified, so a new AuthFailureLoggingMiddleware wrapper was added that sits outside it in the chain and inspects the error on the way back out. 
  * All auth failure reasons use static strings (missing_token, token_expired, token_invalid, etc.) rather than raw error messages to avoid leaking library internals.
* Startup logging (cmd/kessel-relations/main.go)
  * The service now logs a structured startup event after initialization completes, including whether auth is enabled and what addresses gRPC and HTTP are listening on. 
  * Sensitive values like  the JWKS URL and SpiceDB token are not logged.
* Principal extraction helper (internal/service/security_logging.go)
  * A small helper that reads the JWT sub claim from the request context. Unary and streaming RPCs store JWT claims under different context keys (Kratos uses its own key, the custom stream interceptor uses a local one), so this helper checks both.

**Note: changes implemented via the `/productivity-utils:security-logging` skill**

  Events of Interest covered
 | EOI | Category | Where |
  |-----|----------|-------|
  | EOI-1 | `pii_manipulation` | CreateTuples, DeleteTuples, ImportBulkTuples |
  | EOI-4 | `access_manipulation` | CreateTuples, DeleteTuples, ImportBulkTuples, AcquireLock |
  | EOI-5 | `process_status` | Service startup |
  | EOI-7 | `invalid_login` | StreamAuthInterceptor, AuthFailureLoggingMiddleware |
  | EOI-8 | `authorization_failure` | StreamAuthInterceptor, AuthFailureLoggingMiddleware |
  | EOI-11 | `warnings_or_errors` | Failure paths on all write operations |

### Validation (local using binary/podman)

```shell
# startup log
INFO ts=2026-07-22T16:14:08-04:00 caller=log/helper.go:127 service.id=anatale-thinkpadp16vgen1.rmtusga.csb service.name= service.version= trace.id= span.id= msg=Service starting action=STARTUP resource_type=service resource_id= outcome=success service_version= auth_enabled=true grpc_addr=0.0.0.0:9000 http_addr=0.0.0.0:8000

# successful create with valid auth
INFO ts=2026-07-22T20:17:19Z caller=log/helper.go:127 service.id=22608cc7c578 service.name= service.version= trace.id= span.id= msg=Tuples created action=CREATE resource_type=relationship_tuple resource_id=count:0 outcome=success principal=efb84de7-05ea-4535-830b-c5b49cf5050e

# example unauthorized
WARN ts=2026-07-22T16:10:42-04:00 caller=log/helper.go:148 service.id=anatale-thinkpadp16vgen1.rmtusga.csb service.name= service.version= trace.id= span.id= msg=Authentication failed action=AUTHENTICATE resource_type=api_endpoint resource_id=/grpc.reflection.v1.ServerReflection/ServerReflectionInfo outcome=failure reason=token_invalid
ERROR ts=2026-07-22T16:10:42-04:00 caller=log/helper.go:85 service.id=anatale-thinkpadp16vgen1.rmtusga.csb service.name= service.version= trace.id= span.id= kind=server component=server operation=/grpc.reflection.v1.ServerReflection/ServerReflectionInfo args=<nil> code=401 reason=UNAUTHORIZED stack=error: code = 401 reason = UNAUTHORIZED message = Token is invalid metadata = map[] cause = <nil> latency=2.137e-05

# example missing token
WARN ts=2026-07-22T16:11:27-04:00 caller=log/helper.go:148 service.id=anatale-thinkpadp16vgen1.rmtusga.csb service.name= service.version= trace.id= span.id= msg=Authentication failed action=AUTHENTICATE resource_type=api_endpoint resource_id=/grpc.reflection.v1.ServerReflection/ServerReflectionInfo outcome=failure reason=missing_token
ERROR ts=2026-07-22T16:11:27-04:00 caller=log/helper.go:85 service.id=anatale-thinkpadp16vgen1.rmtusga.csb service.name= service.version= trace.id= span.id= kind=server component=server operation=/grpc.reflection.v1.ServerReflection/ServerReflectionInfo args=<nil> code=401 reason=UNAUTHORIZED stack=error: code = 401 reason = UNAUTHORIZED message = JWT token is missing metadata = map[] cause = <nil> latency=1.7522e-05

# example delete with valid auth
INFO ts=2026-07-22T20:18:47Z caller=log/helper.go:127 service.id=22608cc7c578 service.name= service.version= trace.id= span.id= msg=Tuples deleted action=DELETE resource_type=relationship_tuple resource_id=rbac/workspace:my-workspace outcome=success principal=efb84de7-05ea-4535-830b-c5b49cf5050e
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured service-startup logging (identity/version, auth enablement, gRPC/HTTP addresses).
  * Enhanced authentication failure logging for both HTTP and gRPC when auth is enabled, including reason-specific WARN logs.
  * Added SEC-MON-REQ-1 structured compliance logging for tuple lifecycle operations (create/delete/bulk import/lock), covering success and failure outcomes.
* **Bug Fixes**
  * Improved JWT authentication failure categorization and ensured logs include operation-derived resource context when available.
* **Tests**
  * Added/expanded unit tests for authentication failure logging behavior and principal/sub extraction helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->