### PR TITLE
RHCLOUD-48766: spicedb updates to improve structured logging for compliance

### DIFF
--- a/deploy/kessel-relations-deploy.yaml
+++ b/deploy/kessel-relations-deploy.yaml
@@ -10,6 +10,8 @@ objects:
     spec:
       config:
         logLevel: ${SPICEDB_LOG_LEVEL}
+        logFormat: json
+        grpcLogRequestsEnabled: "true"
         replicas: ${{SPICEDB_REPLICAS}}
         datastoreEngine: postgres
         image: ${SPICEDB_IMAGE}


### PR DESCRIPTION
### PR Template:

Updates to SpiceDB configuration to better implement structured logging for SEC-MON-REQ-1 compliance:
* Adds `logFormat: json` to the SpiceDBCluster CR config, explicitly setting SpiceDB pod log output to structured JSON for reliable machine-parsing in CloudWatch (this is default but if default ever changes we are explicit)
* Enables `grpcLogRequestsEnabled: "true"` to log full gRPC request payloads per API call, surfacing relationship tuple identifiers (resource_id) required for EOI-1 and EOI-4 compliance
* Intentionally leaves ephemeral settings as-is to reduce excess logging costs as this change causes extra logging to capture the required fields for compliance

#### Validation

Tested in Ephemeral, the `grpcLogRequestsEnabled` change updates logging to include 2 logs for each SpiceDB method call: once for `request_received` which contains the full protobuf request payload (which is how we'll determine `resource_id`, and `finished_call` to show the request completed

```shell
# Validation of SpiceDB Cluster settings
$ oc get spicedbclusters relations-spicedb -o jsonpath='{.spec.config}' | jq
{
  "datastoreEngine": "postgres",
  "grpcLogRequestsEnabled": "true",
  "image": "quay.io/redhat-services-prod/project-kessel-tenant/kessel-relations/spicedb:latest",
  "logFormat": "json",
  "logLevel": "info",
  "replicas": 1
}

### Example Write Relationships call
# request_received log entry
{"level":"info","protocol":"grpc","grpc.component":"server","grpc.service":"authzed.api.v1.PermissionsService","grpc.method":"WriteRelationships","grpc.method_type":"unary","requestID":"d9kcrq0jeb2s73ftkjpg","peer.address":"10.129.1.197:47536","grpc.start_time":"2026-07-28T15:42:32.859618539Z","grpc.recv.duration":"18.641µs","grpc.request.content":{"updates":[{"operation":2,"relationship":{"resource":{"object_type":"hbi/host","object_id":"72a4b5d6-cd54-4e52-b3af-5f1d6c4e3890"},"relation":"t_workspace","subject":{"object":{"object_type":"rbac/workspace","object_id":"365fe3a3-276e-423f-a2fa-a28668cb482d"}}}}],"optional_preconditions":[{"operation":2,"filter":{"resource_type":"kessel/lock","optional_resource_id":"inventory-consumer/0","optional_relation":"t_version","optional_subject_filter":{"subject_type":"kessel/lockversion","optional_subject_id":"59499618-0576-4945-b1ab-eb7a6a78f135"}}}]},"grpc.time_ms":0,"time":"2026-07-28T15:42:32.859678312Z","message":"request received"} <--

# Example finished call log that comes after it
{"level":"info","protocol":"grpc","grpc.component":"server","grpc.service":"authzed.api.v1.PermissionsService","grpc.method":"WriteRelationships","grpc.method_type":"unary","requestID":"d9kcrq0jeb2s73ftkjpg","peer.address":"10.129.1.197:47536","grpc.start_time":"2026-07-28T15:42:32.859618539Z","grpc.code":"OK","grpc.time_ms":6,"time":"2026-07-28T15:42:32.865784727Z","message":"finished call"} <---

### Same but for Delete Relationship
{"level":"info","protocol":"grpc","grpc.component":"server","grpc.service":"authzed.api.v1.PermissionsService","grpc.method":"DeleteRelationships","grpc.method_type":"unary","requestID":"d9kcrq8jeb2s73ftkjq0","peer.address":"10.129.1.197:47536","grpc.start_time":"2026-07-28T15:42:33.364848415Z","grpc.recv.duration":"14.709µs","grpc.request.content":{"relationship_filter":{"resource_type":"hbi/host","optional_resource_id":"72a4b5d6-cd54-4e52-b3af-5f1d6c4e3890","optional_relation":"t_workspace","optional_subject_filter":{"subject_type":"rbac/workspace","optional_subject_id":"365fe3a3-276e-423f-a2fa-a28668cb482d"}},"optional_preconditions":[{"operation":2,"filter":{"resource_type":"kessel/lock","optional_resource_id":"inventory-consumer/0","optional_relation":"t_version","optional_subject_filter":{"subject_type":"kessel/lockversion","optional_subject_id":"59499618-0576-4945-b1ab-eb7a6a78f135"}}}]},"grpc.time_ms":0,"time":"2026-07-28T15:42:33.364940946Z","message":"request received"}

{"level":"info","protocol":"grpc","grpc.component":"server","grpc.service":"authzed.api.v1.PermissionsService","grpc.method":"DeleteRelationships","grpc.method_type":"unary","requestID":"d9kcrq8jeb2s73ftkjq0","peer.address":"10.129.1.197:47536","grpc.start_time":"2026-07-28T15:42:33.364848415Z","grpc.code":"OK","grpc.time_ms":6,"time":"2026-07-28T15:42:33.371666381Z","message":"finished call"}
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added structured JSON logging for improved log readability and processing.
  * Enabled logging of gRPC requests for enhanced observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->